### PR TITLE
Update frontend resource to bring it within spec

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -10,29 +10,28 @@ objects:
     spec:
       envName: ${ENV_NAME}
       title: Learning resources
+      deploymentRepo: https://github.com/RedHatInsights/learning-resources
       API:
         versions:
           - v1
+      frontend:
+        paths:
+          - /apps/learning-resources
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
-        - id: learningResources
-          appId: learningResources
+        - appId: learningResources
           title: Learning Resources
           href: "/openshift/learning-resources"
-        - id: learningResources
-          appId: learningResources
+        - appId: learningResources
           title: Learning Resources
           href: "/ansible/learning-resources"
-        - id: learningResources
-          appId: learningResources
+        - appId: learningResources
           title: Learning Resources
           href: "/insights/learning-resources"
-        - id: learningResources
-          appId: learningResources
+        - appId: learningResources
           title: Learning Resources
           href: "/edge/learning-resources"
-        - id: learningResources
-          appId: learningResources
+        - appId: learningResources
           title: Learning Resources
           href: "/iam/learning-resources"
       module:
@@ -42,23 +41,11 @@ objects:
             module: ./RootApp
             routes:
               - pathname: "/openshift/learning-resources"
-                props:
-                  bundle: openshift
               - pathname: "/ansible/learning-resources"
-                props:
-                  bundle: ansible
               - pathname: "/insights/learning-resources"
-                props:
-                  bundle: insights
               - pathname: "/edge/learning-resources"
-                props:
-                  bundle: edge
               - pathname: "/settings/learning-resources"
-                props:
-                  bundle: settings
               - pathname: "/iam/learning-resources"
-                props:
-                  bundle: iam
         moduleID: learning-resources
 parameters:
   - name: ENV_NAME


### PR DESCRIPTION
We're seeing deployment failures for frontend-base because of this frontend resource not conforming to the spec:

```
Warning: unknown field "spec.module.modules[0].routes[1].props"
Warning: unknown field "spec.module.modules[0].routes[2].props"
Warning: unknown field "spec.module.modules[0].routes[3].props"
Warning: unknown field "spec.module.modules[0].routes[4].props"
Warning: unknown field "spec.module.modules[0].routes[5].props"
Warning: unknown field "spec.navItems[0].id"
Warning: unknown field "spec.navItems[1].id"
Warning: unknown field "spec.navItems[2].id"
Warning: unknown field "spec.navItems[3].id"
Warning: unknown field "spec.navItems[4].id"
The Frontend "learning-resources" is invalid: 
* spec.deploymentRepo: Required value
* spec.frontend: Required value
 (error details: https://github.com/RedHatInsights/learning-resources/blob/master/deploy/frontend.yml)
```

This patch should bring it inline but give it a good look.