### PR TITLE
[hotfix] add props to frontend and fix appname

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -41,11 +41,23 @@ objects:
             module: ./RootApp
             routes:
               - pathname: "/openshift/learning-resources"
+                props:
+                  bundle: openshift
               - pathname: "/ansible/learning-resources"
+                props:
+                  bundle: ansible
               - pathname: "/insights/learning-resources"
+                props:
+                  bundle: insights
               - pathname: "/edge/learning-resources"
+                props:
+                  bundle: edge
               - pathname: "/settings/learning-resources"
+                props:
+                  bundle: settings
               - pathname: "/iam/learning-resources"
+                props:
+                  bundle: iam
         moduleID: learning-resources
 parameters:
   - name: ENV_NAME

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "webpack-bundle-analyzer": "4.4.2"
   },
   "insights": {
-    "appname": "learningResources"
+    "appname": "learning-resources"
   }
 }


### PR DESCRIPTION
* Adds the correct `props` values back now that they're supported by the operator
* Fixes the appname to match the app id as `learning-resources` instead of `learningResources`