### PR TITLE
Disable global filter in learning resources

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ export const App = ({ bundle }: { bundle: string }) => {
   const targetBundle = bundle || 'settings';
 
   chrome?.updateDocumentTitle?.('Learning Resources');
+  chrome?.hideGlobalFilter?.(true);
 
   useEffect(() => {
     fetch(`/api/quickstarts/v1/quickstarts?bundle=${targetBundle}`)


### PR DESCRIPTION
### Description

By default global filter should be disabled on all learning resources pages. This PR calls chrome UI's function that disables the global filter if applicable.

### JIRA

https://issues.redhat.com/browse/RHCLOUD-29469