### PR TITLE
Hide global filter only on initial render t prevent memory leaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,9 @@ export const App = ({ bundle }: { bundle: string }) => {
   const targetBundle = bundle || 'settings';
 
   chrome?.updateDocumentTitle?.('Learning Resources');
-  chrome?.hideGlobalFilter?.(true);
+  useEffect(() => {
+    chrome?.hideGlobalFilter?.(true);
+  }, []);
 
   useEffect(() => {
     fetch(`/api/quickstarts/v1/quickstarts?bundle=${targetBundle}`)


### PR DESCRIPTION
### Desctiption

If the global filter is not present on a page the learning resources page hangs on inifinite load. This PR makes sure the global filter is disabled only on initial render.