### PR TITLE
Move 'learning resources' widget styling back to  repo

### DIFF
--- a/src/components/LearningResourcesWidget/LearningResourcesWidget.scss
+++ b/src/components/LearningResourcesWidget/LearningResourcesWidget.scss
@@ -1,3 +1,7 @@
+.learningResources-learningResources {
+  overflow-y: auto;
+}
+
 .widget-learning-resources {
   column-width: 300px;
 }

--- a/src/components/LearningResourcesWidget/LearningResourcesWidget.tsx
+++ b/src/components/LearningResourcesWidget/LearningResourcesWidget.tsx
@@ -12,6 +12,8 @@ import LearningResourcesEmptyState from './EmptyState';
 import useQuickStarts from '../../hooks/useQuickStarts';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
+import './LearningResourcesWidget.scss';
+
 export const API_BASE = '/api/quickstarts/v1';
 export const QUICKSTARTS = '/quickstarts';
 export const FAVORITES = '/favorites';


### PR DESCRIPTION
Relates to: https://github.com/RedHatInsights/widget-layout/pull/80
[RHCLOUD-31879](https://issues.redhat.com/browse/RHCLOUD-31879)