### PR TITLE
fix widget bookmarks to match learning resources page

### DIFF
--- a/src/components/LearningResourcesWidget/LearningResourcesWidget.tsx
+++ b/src/components/LearningResourcesWidget/LearningResourcesWidget.tsx
@@ -39,7 +39,7 @@ const LinkWrapper = ({
 };
 
 const LearningResourcesWidget: React.FunctionComponent = () => {
-  const { bookmarks } = useQuickStarts();
+  const { bookmarks } = useQuickStarts('settings');
 
   const getPathName = (url: string) => {
     return new URL(url).host;


### PR DESCRIPTION
fixes [RHCLOUD-32400](https://issues.redhat.com/browse/RHCLOUD-32400)

learning resources bookmark widget now matches the learning resources page 

widget
![image](https://github.com/RedHatInsights/learning-resources/assets/16109803/d28c9675-695c-42ee-9fc9-ae11d67c1a09)
page
![image](https://github.com/RedHatInsights/learning-resources/assets/16109803/048fc58b-db45-443b-81de-f097b3b8d34c)
