### PR TITLE
Show links as external if they lead to external site

### DIFF
--- a/src/components/LearningResourcesWidget/LearningResourcesWidget.tsx
+++ b/src/components/LearningResourcesWidget/LearningResourcesWidget.tsx
@@ -10,7 +10,14 @@ import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
 import { Label } from '@patternfly/react-core/dist/dynamic/components/Label';
 import LearningResourcesEmptyState from './EmptyState';
 import useQuickStarts from '../../hooks/useQuickStarts';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Flex,
+  FlexItem,
+  Icon,
+  Spinner,
+} from '@patternfly/react-core';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 import './LearningResourcesWidget.scss';
 
@@ -39,7 +46,7 @@ const LinkWrapper = ({
 };
 
 const LearningResourcesWidget: React.FunctionComponent = () => {
-  const { bookmarks } = useQuickStarts('settings');
+  const { bookmarks, contentReady } = useQuickStarts('settings');
 
   const getPathName = (url: string) => {
     return new URL(url).host;
@@ -47,35 +54,50 @@ const LearningResourcesWidget: React.FunctionComponent = () => {
 
   return (
     <div>
-      {bookmarks.length === 0 ? (
-        <LearningResourcesEmptyState />
-      ) : (
-        <Gallery className="widget-learning-resources pf-v5-u-p-md" hasGutter>
-          {bookmarks.map(({ spec }, index) => (
-            <div key={index}>
-              <TextContent>
-                <LinkWrapper
-                  title={spec.displayName}
-                  pathname={spec.link?.href || ''}
-                />
-              </TextContent>
-              <Flex direction={{ default: 'row' }}>
-                <FlexItem className="pf-v5-u-mr-sm">
-                  {spec.type && (
-                    <Label color={spec.type.color}>{spec.type.text}</Label>
+      {contentReady ? (
+        bookmarks.length === 0 ? (
+          <LearningResourcesEmptyState />
+        ) : (
+          <Gallery className="widget-learning-resources pf-v5-u-p-md" hasGutter>
+            {bookmarks.map(({ spec, metadata }, index) => (
+              <div key={index}>
+                <TextContent>
+                  {metadata.externalDocumentation ? (
+                    <a href={spec.link?.href} target="_blank" rel="noreferrer">
+                      {spec.displayName}
+                      <Icon className="pf-v5-u-ml-sm" isInline>
+                        <ExternalLinkAltIcon />
+                      </Icon>
+                    </a>
+                  ) : (
+                    <LinkWrapper
+                      title={spec.displayName}
+                      pathname={spec.link?.href || ''}
+                    />
                   )}
-                </FlexItem>
-                <FlexItem>
-                  <TextContent>
-                    <Text component={TextVariants.small}>
-                      {spec.link?.href ? getPathName(spec.link?.href) : ''}
-                    </Text>
-                  </TextContent>
-                </FlexItem>
-              </Flex>
-            </div>
-          ))}
-        </Gallery>
+                </TextContent>
+                <Flex direction={{ default: 'row' }}>
+                  <FlexItem className="pf-v5-u-mr-sm">
+                    {spec.type && (
+                      <Label color={spec.type.color}>{spec.type.text}</Label>
+                    )}
+                  </FlexItem>
+                  <FlexItem>
+                    <TextContent>
+                      <Text component={TextVariants.small}>
+                        {spec.link?.href ? getPathName(spec.link?.href) : ''}
+                      </Text>
+                    </TextContent>
+                  </FlexItem>
+                </Flex>
+              </div>
+            ))}
+          </Gallery>
+        )
+      ) : (
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
       )}
     </div>
   );


### PR DESCRIPTION
### Description

We want to tell user the bookmarked learning resource is leading to external site by visually showing icon and when user clicks on it open a new tab with it.

There's also a bug when learning resources are being loaded the widgets shows no learning resources instead of loading state. This PR add spinner within bulseye to indicate loading.

#### Before
![Screenshot from 2024-05-17 09-17-38](https://github.com/RedHatInsights/learning-resources/assets/3439771/b6d5b307-d60d-4849-a26e-234aa975556a)

#### After
![Screenshot from 2024-05-17 09-17-20](https://github.com/RedHatInsights/learning-resources/assets/3439771/36613b40-0dbe-402c-bae9-577bc7f6cf49)
