### PR TITLE
Update quay references for output images

### DIFF
--- a/.tekton/learning-resources-pull-request.yaml
+++ b/.tekton/learning-resources-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/learning-resources/learning-resources:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/learning-resources:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/learning-resources-push.yaml
+++ b/.tekton/learning-resources-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/learning-resources/learning-resources:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/learning-resources:{{revision}}
   - name: dockerfile
     value: ./Dockerfile
   pipelineSpec:


### PR DESCRIPTION
This was causing `learning-resources` to be output in the quay url for these images.