### PR TITLE
Fix capitalization and URLs in header in Global Learning Resources

### DIFF
--- a/src/components/GlobalLearningResourcesPage/GlobalLearningResourcesHeader.tsx
+++ b/src/components/GlobalLearningResourcesPage/GlobalLearningResourcesHeader.tsx
@@ -39,29 +39,29 @@ export const GlobalLearningResourcesHeader = () => {
               Cloud Console. Find additional resources on{' '}
               <Text
                 component={TextVariants.a}
-                href="https://developers.redhat.com/"
+                href="https://developers.redhat.com/learn"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Developers.RedHat.com
+                developers.redhat.com
               </Text>
               ,{' '}
               <Text
                 component={TextVariants.a}
-                href="https://cloud.redhat.com/"
+                href="https://cloud.redhat.com/learn"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Cloud.RedHat.com
+                cloud.redhat.com
               </Text>
               , and on{' '}
               <Text
                 component={TextVariants.a}
-                href="https://www.redhat.com/"
+                href="https://www.redhat.com/en/resources"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                RedHat.com
+                redhat.com
               </Text>
               .
             </Text>

--- a/src/components/GlobalLearningResourcesPage/GlobalLearningResourcesHeader.tsx
+++ b/src/components/GlobalLearningResourcesPage/GlobalLearningResourcesHeader.tsx
@@ -31,7 +31,7 @@ export const GlobalLearningResourcesHeader = () => {
       <TextContent>
         <Stack className="pf-v5-u-m-lg">
           <StackItem>
-            <Text component={TextVariants.h1}>All Learning Resources</Text>
+            <Text component={TextVariants.h1}>All learning resources</Text>
           </StackItem>
           <StackItem>
             <Text component={TextVariants.p}>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-38239
https://issues.redhat.com/browse/RHCLOUD-38240

Requested changes by UXD:

Developers.RedHat.com → developers.redhat.com (https://developers.redhat.com/learn)
Cloud.RedHat.com → cloud.redhat.com (https://cloud.redhat.com/learn)
RedHat.com → redhat.com (https://www.redhat.com/en/resources)

Change the page header on [All learning resources page ](https://console.redhat.com/learning-resources)from ‘All Learning Resources’ to ‘All learning resources’