### PR TITLE
fix(widget): empty state url to all learning resources

### DIFF
--- a/src/components/LearningResourcesWidget/EmptyState.tsx
+++ b/src/components/LearningResourcesWidget/EmptyState.tsx
@@ -12,8 +12,14 @@ import {
 import BookMarkEmptyState from './Bookmarks_empty-state.svg';
 
 import './empty-state.scss';
+import { useNavigate } from 'react-router-dom';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const LearningResourcesEmptyState: React.FunctionComponent = () => {
+  const navigate = useNavigate();
+  const enableGlobalLearningResourcesPage = useFlag(
+    'platform.learning-resources.global-learning-resources'
+  );
   return (
     <EmptyState variant={EmptyStateVariant.lg} className="pf-v5-u-py-md">
       <EmptyStateHeader
@@ -33,7 +39,19 @@ const LearningResourcesEmptyState: React.FunctionComponent = () => {
         <Button
           variant="secondary"
           component="a"
-          href="settings/learning-resources#documentation"
+          href={
+            enableGlobalLearningResourcesPage
+              ? '/learning-resources'
+              : '/settings/learning-resources'
+          }
+          onClick={(e) => {
+            e.preventDefault();
+            navigate(
+              enableGlobalLearningResourcesPage
+                ? '/learning-resources'
+                : '/settings/learning-resources'
+            );
+          }}
         >
           View all learning resources
         </Button>


### PR DESCRIPTION
## Description

Currently if user adds bookmarked learning resources widget without any bookmarks it shows button which leads to all settings learning resources. This PR fixes it by changing the URL to lead to all learning resources. This new location is hidden behind a feature flag `platform.learning-resources.global-learning-resources`