### PR TITLE
Fix missing learning resources routing definitions.

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -87,6 +87,20 @@ objects:
               - pathname: "/iam/learning-resources"
                 props:
                   bundle: iam
+          - id: globalLearningResourcesPage
+            module: ./GlobalLearningResourcesPage
+            routes:
+              - pathname: /learning-resources
+          - id: learningResourcesCreator
+            module: "./Creator"
+            routes:
+            - pathname: "/learning-resources/creator"
+              exact: true
+              permissions:
+              - method: featureFlag
+                args:
+                - platform.chrome.quickstarts.creator
+                - true
       searchEntries:
         - id: learning-resources
           title: All Learning Resources


### PR DESCRIPTION
The config was not complete when migrating to the new FEO features. This blocks the docs teams from using the quickstarts creation tool.