### PR TITLE
patch: use upcomming root widget CSS selectors

### DIFF
--- a/src/components/LearningResourcesWidget/LearningResourcesWidget.scss
+++ b/src/components/LearningResourcesWidget/LearningResourcesWidget.scss
@@ -1,4 +1,4 @@
-.learningResources-learningResources {
+.learningResources-learningResources, [class*="learningResources-learningResources-./BookmarkedLearningResourcesWidget"] {
   container-type: inline-size;
   overflow-y: auto;
 }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-41601

Changes
Ensures that the root widget element class names match the future widget IDs