### PR TITLE
Fix issues with learning resources FEO migration

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -4,7 +4,12 @@ module.exports = {
   appUrl: [
     '/settings/learning-resources',
     '/openshift/learning-resources',
-    '/staging/global-learning-resources-page',
+    '/ansible/learning-resources',
+    '/insights/learning-resources',
+    '/edge/learning-resources',
+    '/iam/learning-resources',
+    '/learning-resources',
+    '/learning-resources/creator',
   ],
   debug: true,
   useProxy: true,
@@ -45,5 +50,4 @@ module.exports = {
       },
     ],
   },
-  frontendCRDPath: path.resolve(__dirname, './deploy/frontend.yml'),
 };


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/learning-resources/pull/113 & https://github.com/RedHatInsights/chrome-service-backend/pull/841

fixes to `feo.config.js`:
- Added missing `appUrl` entries
- remove duplicate `frontendCRDPath`