### PR TITLE
Add RH status link to help panel

### DIFF
--- a/src/components/HelpPanel/HelpPanelContent.tsx
+++ b/src/components/HelpPanel/HelpPanelContent.tsx
@@ -18,7 +18,9 @@ const HelpPanelContent = ({ toggleDrawer }: { toggleDrawer: () => void }) => {
           Help
           <Button
             variant="link"
-            onClick={() => window.open('https://status.redhat.com/', '_blank')}
+            component="a"
+            href="https://status.redhat.com/"
+            target="_blank"
             isInline
             className="pf-v6-u-font-size-sm pf-v6-u-font-weight-normal pf-v6-u-ml-md"
             icon={<ExternalLinkAltIcon />}

--- a/src/components/HelpPanel/HelpPanelContent.tsx
+++ b/src/components/HelpPanel/HelpPanelContent.tsx
@@ -1,18 +1,32 @@
 import React from 'react';
 import {
+  Button,
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
   DrawerPanelBody,
   Title,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import HelpPanelCustomTabs from './HelpPanelCustomTabs';
 
 const HelpPanelContent = ({ toggleDrawer }: { toggleDrawer: () => void }) => {
   return (
     <>
       <DrawerHead>
-        <Title headingLevel="h2">Help</Title>
+        <Title headingLevel="h2">
+          Help
+          <Button
+            variant="link"
+            onClick={() => window.open('https://status.redhat.com/', '_blank')}
+            isInline
+            className="pf-v6-u-font-size-sm pf-v6-u-font-weight-normal pf-v6-u-ml-md"
+            icon={<ExternalLinkAltIcon />}
+            iconPosition="end"
+          >
+            Red Hat status page
+          </Button>
+        </Title>
         <DrawerActions>
           <DrawerCloseButton onClick={toggleDrawer} />
         </DrawerActions>


### PR DESCRIPTION
2nd part of [RHCLOUD-41903](https://issues.redhat.com/browse/RHCLOUD-41903). 1st part is https://github.com/RedHatInsights/insights-chrome/pull/3169

<img width="521" height="347" alt="image" src="https://github.com/user-attachments/assets/e9be4f66-23b4-4b84-8000-90e03592e8d0" />
