### PR TITLE
Fix Support Tab styling

### DIFF
--- a/src/components/HelpPanel/HelpPanelTabs/SupportPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/SupportPanel.tsx
@@ -194,7 +194,10 @@ const SupportPanel: React.FunctionComponent = () => {
                       {c.summary} <ExternalLinkAltIcon key="icon" />
                     </a>
                   </Td>
-                  <Td dataLabel={columnNames.status}>
+                  <Td
+                    dataLabel={columnNames.status}
+                    className="pf-v6-u-text-nowrap"
+                  >
                     {statusIcons(c.status)}
                   </Td>
                 </Tr>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-41885

Old
<img width="601" height="348" alt="Screenshot 2025-09-09 at 11 06 00 AM" src="https://github.com/user-attachments/assets/e92e3295-2b24-4973-a97b-ed17b58f8c52" />


New
<img width="595" height="333" alt="Screenshot 2025-09-09 at 11 03 45 AM" src="https://github.com/user-attachments/assets/71ee1177-5724-45e0-8df3-285898d70cd4" />
