### PR TITLE
Hide knowledge and search tabs behind FFs

### DIFF
--- a/cypress/component/HelpPanel.cy.tsx
+++ b/cypress/component/HelpPanel.cy.tsx
@@ -4,7 +4,7 @@ import * as chrome from '@redhat-cloud-services/frontend-components/useChrome';
 import HelpPanel from '../../src/components/HelpPanel';
 
 const defaultFlags: IConfig['bootstrap'] = [{
-      name: 'platform.help-panel.kb',
+      name: 'platform.chrome.help-panel_knowledge-base',
       enabled: true,
       impressionData: false,
       variant: {name: 'disabled', enabled: false},

--- a/src/components/HelpPanel/HelpPanelCustomTabs.tsx
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.tsx
@@ -40,6 +40,7 @@ const subTabs: SubTab[] = [
   {
     title: 'Search',
     tabType: TabType.search,
+    featureFlag: 'platform.chrome.help-panel_search',
   },
   {
     title: 'Learn',
@@ -48,7 +49,7 @@ const subTabs: SubTab[] = [
   {
     title: 'Knowledge base',
     tabType: TabType.kb,
-    featureFlag: 'platform.help-panel.kb',
+    featureFlag: 'platform.chrome.help-panel_knowledge-base',
   },
   {
     title: 'APIs',


### PR DESCRIPTION
For [RHCLOUD-41888](https://issues.redhat.com/browse/RHCLOUD-41888). Flags have been created in stage and prod (only enabled in stage at the moment).

<img width="451" height="349" alt="image" src="https://github.com/user-attachments/assets/a90c21f5-cfdc-48f5-8e4b-05b076ae2368" />
