### PR TITLE
feat(statuspage): move statuspage link next to subtabs

### DIFF
--- a/src/components/HelpPanel/HelpPanelContent.tsx
+++ b/src/components/HelpPanel/HelpPanelContent.tsx
@@ -8,26 +8,34 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { useFlag } from '@unleash/proxy-client-react';
 import HelpPanelCustomTabs from './HelpPanelCustomTabs';
 
 const HelpPanelContent = ({ toggleDrawer }: { toggleDrawer: () => void }) => {
+  const searchFlag = useFlag('platform.chrome.help-panel_search');
+  const kbFlag = useFlag('platform.chrome.help-panel_knowledge-base');
+
+  const showStatusPageInHeader = searchFlag && kbFlag;
+
   return (
     <>
       <DrawerHead>
         <Title headingLevel="h2">
           Help
-          <Button
-            variant="link"
-            component="a"
-            href="https://status.redhat.com/"
-            target="_blank"
-            isInline
-            className="pf-v6-u-font-size-sm pf-v6-u-font-weight-normal pf-v6-u-ml-md"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="end"
-          >
-            Red Hat status page
-          </Button>
+          {showStatusPageInHeader && (
+            <Button
+              variant="link"
+              component="a"
+              href="https://status.redhat.com/"
+              target="_blank"
+              isInline
+              className="pf-v6-u-font-size-sm pf-v6-u-font-weight-normal pf-v6-u-ml-md"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="end"
+            >
+              Red Hat status page
+            </Button>
+          )}
         </Title>
         <DrawerActions>
           <DrawerCloseButton onClick={toggleDrawer} />

--- a/src/components/HelpPanel/HelpPanelCustomTabs.scss
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.scss
@@ -16,4 +16,10 @@
       align-self: auto;
     }
   }
+
+}
+
+// Align Red Hat status page button with tabs
+.lr-c-status-page-button {
+  transform: translateY(8px) !important;
 }

--- a/src/components/HelpPanel/HelpPanelCustomTabs.tsx
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.tsx
@@ -1,4 +1,10 @@
-import { Tab, TabTitleText, Tabs, debounce } from '@patternfly/react-core';
+import {
+  Button,
+  Tab,
+  TabTitleText,
+  Tabs,
+  debounce,
+} from '@patternfly/react-core';
 import React, {
   PropsWithChildren,
   ReactNode,
@@ -13,7 +19,8 @@ import classNames from 'classnames';
 import './HelpPanelCustomTabs.scss';
 import HelpPanelTabContainer from './HelpPanelTabs/HelpPanelTabContainer';
 import { TabType } from './HelpPanelTabs/helpPanelTabsMapper';
-import { useFlags } from '@unleash/proxy-client-react';
+import { useFlag, useFlags } from '@unleash/proxy-client-react';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type TabDefinition = {
   id: string;
@@ -147,6 +154,11 @@ const SubTabs = ({
       return true;
     });
   }, [flags, subTabs]);
+
+  const searchFlag = useFlag('platform.chrome.help-panel_search');
+  const kbFlag = useFlag('platform.chrome.help-panel_knowledge-base');
+
+  const showStatusPageButton = !searchFlag && !kbFlag;
   return (
     <>
       <Tabs
@@ -160,13 +172,29 @@ const SubTabs = ({
           }
         }}
       >
-        {filteredSubTabs.map((tab) => (
-          <Tab
-            eventKey={tab.tabType}
-            key={tab.tabType}
-            title={<TabTitleText>{tab.title}</TabTitleText>}
-          />
-        ))}
+        <>
+          {filteredSubTabs.map((tab) => (
+            <Tab
+              eventKey={tab.tabType}
+              key={tab.tabType}
+              title={<TabTitleText>{tab.title}</TabTitleText>}
+            />
+          ))}
+          {showStatusPageButton && (
+            <Button
+              variant="link"
+              component="a"
+              href="https://status.redhat.com/"
+              target="_blank"
+              isInline
+              className="pf-v6-u-font-size-sm pf-v6-u-font-weight-normal pf-v6-u-ml-md lr-c-status-page-button"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="end"
+            >
+              Red Hat status page
+            </Button>
+          )}
+        </>
       </Tabs>
       {children}
     </>


### PR DESCRIPTION
[RHCLOUD-42346](https://issues.redhat.com/browse/RHCLOUD-42346)

For phase 1, we are moving the Red Hat status page link next to the subtabs

<img width="451" height="753" alt="Screenshot From 2025-10-02 16-05-38" src="https://github.com/user-attachments/assets/1f00b110-a4b0-4edf-b478-2ab59666cdff" />


