### PR TITLE
fix(help-panel): default new tab to Search

### DIFF
--- a/src/components/HelpPanel/HelpPanelCustomTabs.test.tsx
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.test.tsx
@@ -225,6 +225,33 @@ describe('HelpPanelCustomTabs UI interactions', () => {
     expect(tabs[2]).toHaveTextContent('New tab');
   });
 
+  it('new tab defaults to Search sub-tab when search flag is enabled', async () => {
+    renderWithIntl(<HelpPanelCustomTabs />);
+    const addTabButton = screen.getByRole('button', { name: /add tab/i });
+    fireEvent.click(addTabButton);
+
+    // Click the new tab to make it active
+    await waitFor(() => {
+      const newTab = screen.getByText('New tab');
+      expect(newTab).toBeInTheDocument();
+      fireEvent.click(newTab);
+    });
+
+    // The new tab should have sub-tabs; the Search sub-tab should be active
+    await waitFor(() => {
+      // Find all sub-tab containers — there may be multiple (one per main tab)
+      const subtabContainers = document.querySelectorAll(
+        '[data-ouia-component-id="help-panel-subtabs"]'
+      );
+      // The last sub-tab container belongs to the newly added tab
+      const lastSubtabs = subtabContainers[subtabContainers.length - 1];
+      const searchSubTab = within(lastSubtabs as HTMLElement).getByRole('tab', {
+        name: /search/i,
+      });
+      expect(searchSubTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
   it('closes an added tab when clicking its close button', () => {
     renderWithIntl(<HelpPanelCustomTabs />);
     fireEvent.click(screen.getByRole('button', { name: /add tab/i }));

--- a/src/components/HelpPanel/HelpPanelCustomTabs.test.tsx
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.test.tsx
@@ -252,6 +252,41 @@ describe('HelpPanelCustomTabs UI interactions', () => {
     });
   });
 
+  it('new tab defaults to Learn sub-tab when search flag is disabled', async () => {
+    mockUseFlag.mockImplementation((flagName: string) => {
+      if (flagName === 'platform.chrome.help-panel_search') return false;
+      if (flagName === 'platform.chrome.help-panel_chatbot') return true;
+      return true;
+    });
+
+    renderWithIntl(<HelpPanelCustomTabs />);
+    const addTabButton = screen.getByRole('button', { name: /add tab/i });
+    fireEvent.click(addTabButton);
+
+    await waitFor(() => {
+      const newTab = screen.getByText('New tab');
+      expect(newTab).toBeInTheDocument();
+      fireEvent.click(newTab);
+    });
+
+    await waitFor(() => {
+      const subtabContainers = document.querySelectorAll(
+        '[data-ouia-component-id="help-panel-subtabs"]'
+      );
+      const lastSubtabs = subtabContainers[subtabContainers.length - 1];
+      const learnSubTab = within(lastSubtabs as HTMLElement).getByRole('tab', {
+        name: /learn/i,
+      });
+      expect(learnSubTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    // Restore default mock
+    mockUseFlag.mockImplementation((flagName: string) => {
+      if (flagName === 'platform.chrome.help-panel_chatbot') return true;
+      return true;
+    });
+  });
+
   it('closes an added tab when clicking its close button', () => {
     renderWithIntl(<HelpPanelCustomTabs />);
     fireEvent.click(screen.getByRole('button', { name: /add tab/i }));

--- a/src/components/HelpPanel/HelpPanelCustomTabs.tsx
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.tsx
@@ -429,11 +429,12 @@ const HelpPanelCustomTabs = React.forwardRef<HelpPanelCustomTabsRef>(
       // The title will be a placeholder until action is taken by the user
       setNewActionTitle(undefined);
       const newTabId = crypto.randomUUID();
+      const defaultTabType = searchFlag ? TabType.search : TabType.learn;
       const tab = {
         id: newTabId,
         title: NEW_TAB_PLACEHOLDER,
         closeable: true,
-        tabType: TabType.learn,
+        tabType: defaultTabType,
         isNewTab: true,
       };
       addTab(tab);


### PR DESCRIPTION
## Summary

- **RHCLOUD-46462**: When the search feature flag is enabled, new tabs created via the Add Tab button now default to the Search sub-tab instead of Learn, matching the behavior of the initial Find Help tab.
- The `handleAddTab` function was hardcoded to `TabType.learn`. Now it respects the `searchFlag` to use `TabType.search` when enabled.
- Added a unit test verifying the new tab defaults to the Search sub-tab.

## Test plan

- [x] All 49 existing unit tests pass
- [x] New test verifies the Search sub-tab is active on new tabs when search flag is enabled
- [x] Lint passes clean
- [x] Visual verification in dev server (UI change — affects sub-tab selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)