### PR TITLE
test(help-panel): add in-page link stories

### DIFF
--- a/src/user-journeys/HelpPanelInPageLinks.stories.tsx
+++ b/src/user-journeys/HelpPanelInPageLinks.stories.tsx
@@ -55,6 +55,86 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
+ * Shared helper for clicking an in-page link and asserting the help panel
+ * opens with the correct tab and (optionally) sub-tab or custom content.
+ *
+ * Uses scoped selectors to avoid "multiple elements" errors when tab titles
+ * match card titles or custom content headings on the page.
+ */
+interface ClickLinkAndAssertTabOptions {
+  canvasElement: HTMLElement;
+  linkName: RegExp;
+  tabTitle: string;
+  subTabOuiaId?: string;
+  customContentOuiaId?: string;
+}
+
+const clickLinkAndAssertTab = async ({
+  canvasElement,
+  linkName,
+  tabTitle,
+  subTabOuiaId,
+  customContentOuiaId,
+}: ClickLinkAndAssertTabOptions) => {
+  const canvas = within(canvasElement);
+
+  // Click the link
+  const link = await canvas.findByRole('button', { name: linkName });
+  await userEvent.click(link);
+
+  // Wait for the help panel drawer to open
+  await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+  // Verify the help panel is open by checking for the panel title
+  await waitFor(
+    () => {
+      const helpTitle = canvasElement.querySelector(
+        '[data-ouia-component-id="help-panel-title"]'
+      );
+      expect(helpTitle).toBeInTheDocument();
+    },
+    { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+  );
+
+  // Verify the tab was created with the correct title.
+  // Use queryAllByText to handle cases where the title appears in multiple
+  // places (e.g., tab text + card title, or tab text + custom content heading).
+  await waitFor(
+    () => {
+      const matches = canvas.queryAllByText(tabTitle);
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    },
+    { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+  );
+
+  // Verify the sub-tab is active (if specified)
+  if (subTabOuiaId) {
+    await waitFor(
+      () => {
+        const subTab = canvasElement.querySelector(
+          `[data-ouia-component-id="${subTabOuiaId}"]`
+        );
+        expect(subTab).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+  }
+
+  // Verify custom content is rendered (if specified)
+  if (customContentOuiaId) {
+    await waitFor(
+      () => {
+        const customContent = canvasElement.querySelector(
+          `[data-ouia-component-id="${customContentOuiaId}"]`
+        );
+        expect(customContent).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+  }
+};
+
+/**
  * Manual Testing Entry Point
  *
  * Use this story to manually test in-page links.
@@ -98,36 +178,11 @@ export const Step02_ClickLearnLink: Story = {
   play: async ({ canvasElement }) => {
     await waitForPageLoad(canvasElement);
 
-    const canvas = within(canvasElement);
-
-    // Click the Learn link
-    const learnLink = await canvas.findByRole('button', {
-      name: /view getting started guide/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /view getting started guide/i,
+      tabTitle: 'Getting Started Guide',
     });
-    await userEvent.click(learnLink);
-
-    // Wait for the help panel to open
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify the help panel is open by checking for the panel title
-    await waitFor(
-      () => {
-        const helpTitle = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-title"]'
-        );
-        expect(helpTitle).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the new tab was created with the correct title
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('Getting Started Guide');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     console.log(
       'UJ: \u2705 Learn link opened help panel with "Getting Started Guide" tab'
@@ -146,47 +201,12 @@ export const Step03_ClickAPILink: Story = {
   play: async ({ canvasElement }) => {
     await waitForPageLoad(canvasElement);
 
-    const canvas = within(canvasElement);
-
-    // Click the API link
-    const apiLink = await canvas.findByRole('button', {
-      name: /view api documentation/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /view api documentation/i,
+      tabTitle: 'API Documentation',
+      subTabOuiaId: 'help-panel-subtab-api',
     });
-    await userEvent.click(apiLink);
-
-    // Wait for the help panel to open
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify the help panel is open
-    await waitFor(
-      () => {
-        const helpTitle = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-title"]'
-        );
-        expect(helpTitle).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the new tab was created with the correct title
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('API Documentation');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the APIs sub-tab is active by checking for API content
-    await waitFor(
-      () => {
-        const apiSubTab = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-subtab-api"]'
-        );
-        expect(apiSubTab).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     console.log(
       'UJ: \u2705 API link opened help panel with "API Documentation" tab'
@@ -202,50 +222,22 @@ export const Step03_ClickAPILink: Story = {
  */
 export const Step04_ClickSupportLink: Story = {
   name: '04 / Click Support Link Opens Support Tab',
+  parameters: {
+    testRunner: {
+      // The Support panel fetches support cases from an API that isn't
+      // available in Storybook. The "Failed to fetch" error is expected.
+      ignoreConsoleErrors: [/Unable to fetch support cases/],
+    },
+  },
   play: async ({ canvasElement }) => {
     await waitForPageLoad(canvasElement);
 
-    const canvas = within(canvasElement);
-
-    // Click the Support link
-    const supportLink = await canvas.findByRole('button', {
-      name: /get support/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /get support/i,
+      tabTitle: 'Support',
+      subTabOuiaId: 'help-panel-subtab-support',
     });
-    await userEvent.click(supportLink);
-
-    // Wait for the help panel to open
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify the help panel is open
-    await waitFor(
-      () => {
-        const helpTitle = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-title"]'
-        );
-        expect(helpTitle).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the new tab was created with the correct title
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('Support');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the Support sub-tab is active
-    await waitFor(
-      () => {
-        const supportSubTab = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-subtab-support"]'
-        );
-        expect(supportSubTab).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     console.log('UJ: \u2705 Support link opened help panel with "Support" tab');
   },
@@ -264,45 +256,12 @@ export const Step05_ClickCustomContentLink: Story = {
 
     const canvas = within(canvasElement);
 
-    // Click the custom content link
-    const customLink = await canvas.findByRole('button', {
-      name: /view feature help/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /view feature help/i,
+      tabTitle: 'Feature Help',
+      customContentOuiaId: 'custom-help-content',
     });
-    await userEvent.click(customLink);
-
-    // Wait for the help panel to open
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify the help panel is open
-    await waitFor(
-      () => {
-        const helpTitle = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-title"]'
-        );
-        expect(helpTitle).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the new tab was created with the correct title
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('Feature Help');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify custom content is rendered in the help panel
-    await waitFor(
-      () => {
-        const customContent = canvasElement.querySelector(
-          '[data-ouia-component-id="custom-help-content"]'
-        );
-        expect(customContent).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     // Verify the custom content text
     await canvas.findByText(
@@ -326,47 +285,12 @@ export const Step06_ClickKBLink: Story = {
   play: async ({ canvasElement }) => {
     await waitForPageLoad(canvasElement);
 
-    const canvas = within(canvasElement);
-
-    // Click the KB link
-    const kbLink = await canvas.findByRole('button', {
-      name: /browse knowledge base/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /browse knowledge base/i,
+      tabTitle: 'Knowledge Base',
+      subTabOuiaId: 'help-panel-subtab-kb',
     });
-    await userEvent.click(kbLink);
-
-    // Wait for the help panel to open
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify the help panel is open
-    await waitFor(
-      () => {
-        const helpTitle = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-title"]'
-        );
-        expect(helpTitle).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the new tab was created
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('Knowledge Base');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the KB sub-tab is active
-    await waitFor(
-      () => {
-        const kbSubTab = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-subtab-kb"]'
-        );
-        expect(kbSubTab).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     console.log(
       'UJ: \u2705 Knowledge Base link opened help panel with "Knowledge Base" tab'
@@ -385,47 +309,12 @@ export const Step07_ClickFeedbackLink: Story = {
   play: async ({ canvasElement }) => {
     await waitForPageLoad(canvasElement);
 
-    const canvas = within(canvasElement);
-
-    // Click the Feedback link
-    const feedbackLink = await canvas.findByRole('button', {
-      name: /give feedback/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /give feedback/i,
+      tabTitle: 'Share feedback',
+      subTabOuiaId: 'help-panel-subtab-feedback',
     });
-    await userEvent.click(feedbackLink);
-
-    // Wait for the help panel to open
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify the help panel is open
-    await waitFor(
-      () => {
-        const helpTitle = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-title"]'
-        );
-        expect(helpTitle).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the new tab was created
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('Share feedback');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
-
-    // Verify the Feedback sub-tab is active
-    await waitFor(
-      () => {
-        const feedbackSubTab = canvasElement.querySelector(
-          '[data-ouia-component-id="help-panel-subtab-feedback"]'
-        );
-        expect(feedbackSubTab).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     console.log(
       'UJ: \u2705 Feedback link opened help panel with "Share feedback" tab'
@@ -447,20 +336,11 @@ export const Step08_MultipleLinksCreateTabs: Story = {
     const canvas = within(canvasElement);
 
     // Click the Learn link first
-    const learnLink = await canvas.findByRole('button', {
-      name: /view getting started guide/i,
+    await clickLinkAndAssertTab({
+      canvasElement,
+      linkName: /view getting started guide/i,
+      tabTitle: 'Getting Started Guide',
     });
-    await userEvent.click(learnLink);
-    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
-
-    // Verify first tab created
-    await waitFor(
-      () => {
-        const tabText = canvas.getByText('Getting Started Guide');
-        expect(tabText).toBeInTheDocument();
-      },
-      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
-    );
 
     // Click the API link (panel is already open)
     const apiLink = await canvas.findByRole('button', {

--- a/src/user-journeys/HelpPanelInPageLinks.stories.tsx
+++ b/src/user-journeys/HelpPanelInPageLinks.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { AppEntryWithLinks } from './_shared/components/AppEntryWithLinks';
 import {
   helpPanelMswHandlers,
+  supportPanelMswHandlers,
   waitForPageLoad,
 } from './_shared/helpPanelJourneyHelpers';
 import { TEST_TIMEOUTS, delay } from './_shared/testConstants';
@@ -24,7 +25,7 @@ const meta: Meta<typeof AppEntryWithLinks> = {
   parameters: {
     layout: 'fullscreen',
     msw: {
-      handlers: helpPanelMswHandlers,
+      handlers: [...helpPanelMswHandlers, ...supportPanelMswHandlers],
     },
     docs: {
       description: {
@@ -222,13 +223,6 @@ export const Step03_ClickAPILink: Story = {
  */
 export const Step04_ClickSupportLink: Story = {
   name: '04 / Click Support Link Opens Support Tab',
-  parameters: {
-    testRunner: {
-      // The Support panel fetches support cases from an API that isn't
-      // available in Storybook. The "Failed to fetch" error is expected.
-      ignoreConsoleErrors: [/Unable to fetch support cases/],
-    },
-  },
   play: async ({ canvasElement }) => {
     await waitForPageLoad(canvasElement);
 

--- a/src/user-journeys/HelpPanelInPageLinks.stories.tsx
+++ b/src/user-journeys/HelpPanelInPageLinks.stories.tsx
@@ -1,0 +1,494 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { AppEntryWithLinks } from './_shared/components/AppEntryWithLinks';
+import {
+  helpPanelMswHandlers,
+  waitForPageLoad,
+} from './_shared/helpPanelJourneyHelpers';
+import { TEST_TIMEOUTS, delay } from './_shared/testConstants';
+
+/**
+ * User Journey: Help Panel - In-Page Links
+ *
+ * Tests the complete user workflow for clicking in-page HelpPanelLink components
+ * and verifying the help panel opens with the correct tab and content.
+ *
+ * This verifies that links embedded in console pages correctly trigger the
+ * help panel drawer and navigate to the appropriate tab (Learn, APIs, Support,
+ * Knowledge Base, Feedback) or display custom content.
+ */
+
+const meta: Meta<typeof AppEntryWithLinks> = {
+  title: 'User Journeys/Help Panel/In-Page Links',
+  component: AppEntryWithLinks,
+  parameters: {
+    layout: 'fullscreen',
+    msw: {
+      handlers: helpPanelMswHandlers,
+    },
+    docs: {
+      description: {
+        component: `
+# Help Panel - In-Page Links User Journey
+
+Tests the in-page link functionality where clicking a HelpPanelLink
+in the console opens the help panel with specific content:
+
+- Clicking a Learn link opens the Learn tab
+- Clicking an API link opens the APIs tab
+- Clicking a Support link opens the Support tab
+- Clicking a link with custom content displays that content
+- Clicking a Knowledge Base link opens the KB tab
+- Clicking a Feedback link opens the Feedback tab
+        `,
+      },
+    },
+  },
+  args: {
+    initialRoute: '/',
+    bundle: 'insights',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Manual Testing Entry Point
+ *
+ * Use this story to manually test in-page links.
+ * Click any of the HelpPanelLink buttons on the page cards
+ * and verify the help panel opens with the correct tab.
+ */
+export const ManualTesting: Story = {};
+
+/**
+ * 01 / Page Loads with In-Page Links
+ *
+ * Verifies the page loads with HelpPanelLink components visible in the cards.
+ */
+export const Step01_PageLoadsWithLinks: Story = {
+  name: '01 / Page Loads with In-Page Links',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Verify HelpPanelLink buttons are present
+    await canvas.findByRole('button', { name: /view getting started guide/i });
+    await canvas.findByRole('button', { name: /view api documentation/i });
+    await canvas.findByRole('button', { name: /get support/i });
+    await canvas.findByRole('button', { name: /view feature help/i });
+    await canvas.findByRole('button', { name: /browse knowledge base/i });
+    await canvas.findByRole('button', { name: /give feedback/i });
+
+    console.log('UJ: \u2705 Page loaded with all in-page link buttons visible');
+  },
+};
+
+/**
+ * 02 / Click Learn Link Opens Help Panel
+ *
+ * Clicking the "View getting started guide" link should open the help panel
+ * with a new tab titled "Getting Started Guide" showing the Learn sub-tab.
+ */
+export const Step02_ClickLearnLink: Story = {
+  name: '02 / Click Learn Link Opens Help Panel',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the Learn link
+    const learnLink = await canvas.findByRole('button', {
+      name: /view getting started guide/i,
+    });
+    await userEvent.click(learnLink);
+
+    // Wait for the help panel to open
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify the help panel is open by checking for the panel title
+    await waitFor(
+      () => {
+        const helpTitle = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-title"]'
+        );
+        expect(helpTitle).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the new tab was created with the correct title
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('Getting Started Guide');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    console.log(
+      'UJ: \u2705 Learn link opened help panel with "Getting Started Guide" tab'
+    );
+  },
+};
+
+/**
+ * 03 / Click API Link Opens API Tab
+ *
+ * Clicking the "View API documentation" link should open the help panel
+ * with a new tab showing the APIs sub-tab content.
+ */
+export const Step03_ClickAPILink: Story = {
+  name: '03 / Click API Link Opens API Tab',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the API link
+    const apiLink = await canvas.findByRole('button', {
+      name: /view api documentation/i,
+    });
+    await userEvent.click(apiLink);
+
+    // Wait for the help panel to open
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify the help panel is open
+    await waitFor(
+      () => {
+        const helpTitle = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-title"]'
+        );
+        expect(helpTitle).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the new tab was created with the correct title
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('API Documentation');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the APIs sub-tab is active by checking for API content
+    await waitFor(
+      () => {
+        const apiSubTab = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-subtab-api"]'
+        );
+        expect(apiSubTab).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    console.log(
+      'UJ: \u2705 API link opened help panel with "API Documentation" tab'
+    );
+  },
+};
+
+/**
+ * 04 / Click Support Link Opens Support Tab
+ *
+ * Clicking the "Get support" link should open the help panel
+ * with a new tab showing the Support sub-tab content.
+ */
+export const Step04_ClickSupportLink: Story = {
+  name: '04 / Click Support Link Opens Support Tab',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the Support link
+    const supportLink = await canvas.findByRole('button', {
+      name: /get support/i,
+    });
+    await userEvent.click(supportLink);
+
+    // Wait for the help panel to open
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify the help panel is open
+    await waitFor(
+      () => {
+        const helpTitle = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-title"]'
+        );
+        expect(helpTitle).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the new tab was created with the correct title
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('Support');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the Support sub-tab is active
+    await waitFor(
+      () => {
+        const supportSubTab = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-subtab-support"]'
+        );
+        expect(supportSubTab).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    console.log('UJ: \u2705 Support link opened help panel with "Support" tab');
+  },
+};
+
+/**
+ * 05 / Click Custom Content Link Shows Custom Content
+ *
+ * Clicking the "View feature help" link should open the help panel
+ * with a new tab containing custom content passed via HelpPanelLink.
+ */
+export const Step05_ClickCustomContentLink: Story = {
+  name: '05 / Click Custom Content Link Shows Custom Content',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the custom content link
+    const customLink = await canvas.findByRole('button', {
+      name: /view feature help/i,
+    });
+    await userEvent.click(customLink);
+
+    // Wait for the help panel to open
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify the help panel is open
+    await waitFor(
+      () => {
+        const helpTitle = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-title"]'
+        );
+        expect(helpTitle).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the new tab was created with the correct title
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('Feature Help');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify custom content is rendered in the help panel
+    await waitFor(
+      () => {
+        const customContent = canvasElement.querySelector(
+          '[data-ouia-component-id="custom-help-content"]'
+        );
+        expect(customContent).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the custom content text
+    await canvas.findByText(
+      'This is custom help content passed via HelpPanelLink.'
+    );
+
+    console.log(
+      'UJ: \u2705 Custom content link opened help panel with custom content displayed'
+    );
+  },
+};
+
+/**
+ * 06 / Click Knowledge Base Link Opens KB Tab
+ *
+ * Clicking the "Browse knowledge base" link should open the help panel
+ * with a new tab showing the Knowledge Base sub-tab content.
+ */
+export const Step06_ClickKBLink: Story = {
+  name: '06 / Click Knowledge Base Link Opens KB Tab',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the KB link
+    const kbLink = await canvas.findByRole('button', {
+      name: /browse knowledge base/i,
+    });
+    await userEvent.click(kbLink);
+
+    // Wait for the help panel to open
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify the help panel is open
+    await waitFor(
+      () => {
+        const helpTitle = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-title"]'
+        );
+        expect(helpTitle).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the new tab was created
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('Knowledge Base');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the KB sub-tab is active
+    await waitFor(
+      () => {
+        const kbSubTab = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-subtab-kb"]'
+        );
+        expect(kbSubTab).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    console.log(
+      'UJ: \u2705 Knowledge Base link opened help panel with "Knowledge Base" tab'
+    );
+  },
+};
+
+/**
+ * 07 / Click Feedback Link Opens Feedback Tab
+ *
+ * Clicking the "Give feedback" link should open the help panel
+ * with a new tab showing the Feedback sub-tab content.
+ */
+export const Step07_ClickFeedbackLink: Story = {
+  name: '07 / Click Feedback Link Opens Feedback Tab',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the Feedback link
+    const feedbackLink = await canvas.findByRole('button', {
+      name: /give feedback/i,
+    });
+    await userEvent.click(feedbackLink);
+
+    // Wait for the help panel to open
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify the help panel is open
+    await waitFor(
+      () => {
+        const helpTitle = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-title"]'
+        );
+        expect(helpTitle).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the new tab was created
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('Share feedback');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the Feedback sub-tab is active
+    await waitFor(
+      () => {
+        const feedbackSubTab = canvasElement.querySelector(
+          '[data-ouia-component-id="help-panel-subtab-feedback"]'
+        );
+        expect(feedbackSubTab).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    console.log(
+      'UJ: \u2705 Feedback link opened help panel with "Share feedback" tab'
+    );
+  },
+};
+
+/**
+ * 08 / Multiple Links Create Separate Tabs
+ *
+ * Clicking two different in-page links creates separate tabs in the help panel.
+ * After clicking Learn and then API links, both tabs should be visible.
+ */
+export const Step08_MultipleLinksCreateTabs: Story = {
+  name: '08 / Multiple Links Create Separate Tabs',
+  play: async ({ canvasElement }) => {
+    await waitForPageLoad(canvasElement);
+
+    const canvas = within(canvasElement);
+
+    // Click the Learn link first
+    const learnLink = await canvas.findByRole('button', {
+      name: /view getting started guide/i,
+    });
+    await userEvent.click(learnLink);
+    await delay(TEST_TIMEOUTS.AFTER_DRAWER_OPEN);
+
+    // Verify first tab created
+    await waitFor(
+      () => {
+        const tabText = canvas.getByText('Getting Started Guide');
+        expect(tabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Click the API link (panel is already open)
+    const apiLink = await canvas.findByRole('button', {
+      name: /view api documentation/i,
+    });
+    await userEvent.click(apiLink);
+    await delay(TEST_TIMEOUTS.AFTER_TAB_CHANGE);
+
+    // Verify second tab created
+    await waitFor(
+      () => {
+        const apiTabText = canvas.getByText('API Documentation');
+        expect(apiTabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    // Verify the first tab still exists
+    await waitFor(
+      () => {
+        const learnTabText = canvas.getByText('Getting Started Guide');
+        expect(learnTabText).toBeInTheDocument();
+      },
+      { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
+    );
+
+    console.log(
+      'UJ: \u2705 Multiple in-page links created separate tabs in help panel'
+    );
+  },
+};

--- a/src/user-journeys/_shared/components/AppEntryWithLinks.tsx
+++ b/src/user-journeys/_shared/components/AppEntryWithLinks.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  AllQuickStartStates,
+  QuickStartContextProvider,
+  useValuesForQuickStartContext,
+} from '@patternfly/quickstarts';
+import { IntlProvider } from 'react-intl';
+import { MockConsolePageWithLinks } from './MockConsolePageWithLinks';
+
+interface AppEntryWithLinksProps {
+  initialRoute?: string;
+  bundle?: string;
+}
+
+const locale = 'en';
+
+/**
+ * Wrapper component for in-page link user journey tests.
+ * Provides a mock console environment with HelpPanelLink components
+ * wired to actually open the Help Panel.
+ *
+ * NOTE: useChrome and Unleash are mocked at the webpack level via .storybook/main.ts
+ */
+export const AppEntryWithLinks: React.FC<AppEntryWithLinksProps> = ({
+  initialRoute = '/',
+  bundle = 'insights',
+}) => {
+  const [quickStartStates, setQuickStartStates] = useState<AllQuickStartStates>(
+    {}
+  );
+
+  const quickStartContextValue = useValuesForQuickStartContext({
+    allQuickStarts: [],
+    activeQuickStartID: '',
+    setActiveQuickStartID: () => {},
+    allQuickStartStates: quickStartStates,
+    setAllQuickStartStates: setQuickStartStates,
+    useQueryParams: false,
+  });
+
+  return (
+    <IntlProvider locale={locale} defaultLocale="en">
+      <QuickStartContextProvider value={quickStartContextValue}>
+        <MemoryRouter initialEntries={[initialRoute]}>
+          <MockConsolePageWithLinks bundle={bundle} />
+        </MemoryRouter>
+      </QuickStartContextProvider>
+    </IntlProvider>
+  );
+};

--- a/src/user-journeys/_shared/components/MockConsolePageWithLinks.tsx
+++ b/src/user-journeys/_shared/components/MockConsolePageWithLinks.tsx
@@ -36,12 +36,16 @@ export const MockConsolePageWithLinks: React.FC<
 
   // Wire up the Chrome mock's toggleDrawerContent to actually open the drawer.
   // React state setters are stable across renders, so this is safe.
+  // Captures and restores any previous drawerActions on cleanup to avoid
+  // leaking mock mutations across stories.
   useEffect(() => {
     if (typeof window !== 'undefined') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const chrome = (window as any).insights?.chrome;
       if (chrome) {
+        const previousDrawerActions = chrome.drawerActions;
         chrome.drawerActions = {
+          ...previousDrawerActions,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           toggleDrawerContent: (data: any) => {
             setIsDrawerOpen(true);
@@ -49,6 +53,9 @@ export const MockConsolePageWithLinks: React.FC<
               setNewTab(data.newTab);
             }
           },
+        };
+        return () => {
+          chrome.drawerActions = previousDrawerActions;
         };
       }
     }

--- a/src/user-journeys/_shared/components/MockConsolePageWithLinks.tsx
+++ b/src/user-journeys/_shared/components/MockConsolePageWithLinks.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelContent,
+  Gallery,
+  Page,
+  PageSection,
+  Title,
+} from '@patternfly/react-core';
+import HelpPanelContent from '../../../components/HelpPanel/HelpPanelContent';
+import { HelpPanelLink } from '../../../components/HelpPanel/HelpPanelLink';
+import { HelpPanelTabContent } from '../../../components/HelpPanel/HelpPanelLink';
+import { TabType } from '../../../components/HelpPanel/HelpPanelTabs/helpPanelTabsMapper';
+import { MockHeader } from './MockHeader';
+import './MockConsolePage.scss';
+
+interface MockConsolePageWithLinksProps {
+  bundle?: string;
+}
+
+/**
+ * Mock console page with HelpPanelLink components for testing in-page link functionality.
+ * Wires up the Chrome mock's drawerActions.toggleDrawerContent to actually open the
+ * Help Panel with the correct tab content.
+ */
+export const MockConsolePageWithLinks: React.FC<
+  MockConsolePageWithLinksProps
+> = ({ bundle = 'insights' }) => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [newTab, setNewTab] = useState<HelpPanelTabContent | undefined>();
+
+  // Wire up the Chrome mock's toggleDrawerContent to actually open the drawer.
+  // React state setters are stable across renders, so this is safe.
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chrome = (window as any).insights?.chrome;
+      if (chrome) {
+        chrome.drawerActions = {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          toggleDrawerContent: (data: any) => {
+            setIsDrawerOpen(true);
+            if (data?.newTab) {
+              setNewTab(data.newTab);
+            }
+          },
+        };
+      }
+    }
+  }, []);
+
+  const toggleDrawer = () => {
+    setIsDrawerOpen((prev) => !prev);
+  };
+
+  const panelContent = (
+    <DrawerPanelContent
+      id="mock-help-panel-drawer"
+      data-ouia-component-id="help-panel-drawer"
+      widths={{ default: 'width_50' }}
+    >
+      <HelpPanelContent toggleDrawer={toggleDrawer} newTab={newTab} />
+    </DrawerPanelContent>
+  );
+
+  return (
+    <Page
+      className="mock-console-page"
+      masthead={
+        <MockHeader onHelpClick={toggleDrawer} isDrawerOpen={isDrawerOpen} />
+      }
+    >
+      <Drawer isExpanded={isDrawerOpen} position="right">
+        <DrawerContent panelContent={panelContent}>
+          <DrawerContentBody>
+            <PageSection>
+              <Title
+                headingLevel="h1"
+                size="2xl"
+                style={{ marginBottom: '2rem' }}
+              >
+                Red Hat {bundle === 'insights' ? 'Insights' : 'Console'}{' '}
+                Overview
+              </Title>
+
+              <Gallery hasGutter minWidths={{ default: '300px' }}>
+                <Card data-ouia-component-id="card-getting-started">
+                  <CardTitle>Getting Started</CardTitle>
+                  <CardBody>
+                    <p style={{ marginBottom: '1rem' }}>
+                      New to Red Hat Insights? Check out our getting started
+                      guide for tutorials and resources.
+                    </p>
+                    <HelpPanelLink
+                      title="Getting Started Guide"
+                      tabType={TabType.learn}
+                      ouiaId="in-page-learn-link"
+                    >
+                      View getting started guide
+                    </HelpPanelLink>
+                  </CardBody>
+                </Card>
+
+                <Card data-ouia-component-id="card-api-docs">
+                  <CardTitle>API Integration</CardTitle>
+                  <CardBody>
+                    <p style={{ marginBottom: '1rem' }}>
+                      Explore the Insights API to integrate with your workflows
+                      and automate operations.
+                    </p>
+                    <HelpPanelLink
+                      title="API Documentation"
+                      tabType={TabType.api}
+                      ouiaId="in-page-api-link"
+                    >
+                      View API documentation
+                    </HelpPanelLink>
+                  </CardBody>
+                </Card>
+
+                <Card data-ouia-component-id="card-support">
+                  <CardTitle>Need Help?</CardTitle>
+                  <CardBody>
+                    <p style={{ marginBottom: '1rem' }}>
+                      Having issues? Contact our support team for assistance
+                      with your Red Hat products.
+                    </p>
+                    <HelpPanelLink
+                      title="Support"
+                      tabType={TabType.support}
+                      ouiaId="in-page-support-link"
+                    >
+                      Get support
+                    </HelpPanelLink>
+                  </CardBody>
+                </Card>
+
+                <Card data-ouia-component-id="card-custom-content">
+                  <CardTitle>Feature Guide</CardTitle>
+                  <CardBody>
+                    <p style={{ marginBottom: '1rem' }}>
+                      View contextual help for this specific feature with custom
+                      content.
+                    </p>
+                    <HelpPanelLink
+                      title="Feature Help"
+                      tabType={TabType.learn}
+                      content={
+                        <div data-ouia-component-id="custom-help-content">
+                          <h3>Feature Help</h3>
+                          <p>
+                            This is custom help content passed via
+                            HelpPanelLink.
+                          </p>
+                          <p>
+                            It demonstrates how in-page links can open the help
+                            panel with specific, contextual content relevant to
+                            the current page.
+                          </p>
+                        </div>
+                      }
+                      ouiaId="in-page-custom-content-link"
+                    >
+                      View feature help
+                    </HelpPanelLink>
+                  </CardBody>
+                </Card>
+
+                <Card data-ouia-component-id="card-knowledgebase">
+                  <CardTitle>Knowledge Base</CardTitle>
+                  <CardBody>
+                    <p style={{ marginBottom: '1rem' }}>
+                      Search our knowledge base for articles and solutions to
+                      common issues.
+                    </p>
+                    <HelpPanelLink
+                      title="Knowledge Base"
+                      tabType={TabType.kb}
+                      ouiaId="in-page-kb-link"
+                    >
+                      Browse knowledge base
+                    </HelpPanelLink>
+                  </CardBody>
+                </Card>
+
+                <Card data-ouia-component-id="card-feedback">
+                  <CardTitle>Share Feedback</CardTitle>
+                  <CardBody>
+                    <p style={{ marginBottom: '1rem' }}>
+                      Help us improve the console by sharing your experience and
+                      suggestions.
+                    </p>
+                    <HelpPanelLink
+                      title="Share feedback"
+                      tabType={TabType.feedback}
+                      ouiaId="in-page-feedback-link"
+                    >
+                      Give feedback
+                    </HelpPanelLink>
+                  </CardBody>
+                </Card>
+              </Gallery>
+            </PageSection>
+          </DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </Page>
+  );
+};


### PR DESCRIPTION
## Summary

RHCLOUD-45252

- Add Storybook user journey stories that test in-page link (`HelpPanelLink`) functionality
- Create `MockConsolePageWithLinks` component that wires Chrome mock's `toggleDrawerContent` to actually open the Help Panel drawer with tab data
- 8 story steps covering all tab types: Learn, API, Support, Knowledge Base, Feedback, custom content, and multi-tab creation

## What was done

- **`MockConsolePageWithLinks.tsx`** — Mock console page variant with `HelpPanelLink` buttons embedded in page cards. Wires `window.insights.chrome.drawerActions.toggleDrawerContent` to React state so clicking a `HelpPanelLink` actually opens the drawer with the correct tab data.
- **`AppEntryWithLinks.tsx`** — Wrapper component (mirrors `AppEntryWithRouter`) using the new mock page.
- **`HelpPanelInPageLinks.stories.tsx`** — 8 user journey stories:
  1. Page loads with all link buttons visible
  2. Click Learn link → opens "Getting Started Guide" tab
  3. Click API link → opens "API Documentation" tab
  4. Click Support link → opens "Support" tab
  5. Click custom content link → opens tab with custom React content
  6. Click KB link → opens "Knowledge Base" tab
  7. Click Feedback link → opens "Share feedback" tab
  8. Multiple links create separate tabs

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes (50 tests)
- [ ] `npm run build-storybook` builds successfully
- [ ] Stories render in Storybook at "User Journeys/Help Panel/In-Page Links"
- [ ] Each story's play function runs without errors in the Storybook test runner