### PR TITLE
fix: clean up unit test script

### DIFF
--- a/.tekton/learning-resources-pull-request.yaml
+++ b/.tekton/learning-resources-pull-request.yaml
@@ -49,7 +49,8 @@ spec:
       #!/bin/bash
       set -ex
 
-      npm install
+      # This duplicates the workspace setup script's purpose, don't do it.
+      # npm install
   - name: run-app-script
     value: |
       #!/bin/sh


### PR DESCRIPTION
Explicitly commented-out the npm install in the unit test script; it duplicates what is done in the workspace setup script and may cause issues. Left a comment so that nobody will be tempted to put it back.