### PR TITLE
Update api tab doc link

### DIFF
--- a/cypress/component/HelpPanel.cy.tsx
+++ b/cypress/component/HelpPanel.cy.tsx
@@ -211,10 +211,9 @@ describe('HelpPanel', () => {
     cy.contains('OpenShift').should('be.visible');
     cy.contains('Settings').should('be.visible');
 
-    // Check external link
+    // Check internal link
     cy.contains(getMessageText('apiDocumentationCatalogLinkText'))
-      .should('have.attr', 'href', 'https://developers.redhat.com/api-catalog/')
-      .should('have.attr', 'target', '_blank');
+      .should('have.attr', 'href', 'https://console.redhat.com/docs/api');
   });
 
   it('should create new panel tab', () => {

--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.stories.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.stories.tsx
@@ -126,7 +126,7 @@ export const Default: Story = {
     const catalogLink = canvas.getByText(/API Documentation Catalog/i);
     expect(catalogLink.closest('a')).toHaveAttribute(
       'href',
-      'https://developers.redhat.com/api-catalog/'
+      'https://console.redhat.com/docs/api'
     );
 
     // API names are now capitalized and "API" suffix is stripped

--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
@@ -324,11 +324,8 @@ const APIPanelContent: React.FC = () => {
           <Button
             variant="link"
             component="a"
-            target="_blank"
-            icon={<ExternalLinkAltIcon />}
-            href="https://developers.redhat.com/api-catalog/"
+            href="https://console.redhat.com/docs/api"
             isInline
-            iconPosition="end"
             data-ouia-component-id="help-panel-api-docs-link"
           >
             {intl.formatMessage(messages.apiDocumentationCatalogLinkText)}

--- a/src/user-journeys/HelpPanelAPIPanel.stories.tsx
+++ b/src/user-journeys/HelpPanelAPIPanel.stories.tsx
@@ -101,7 +101,7 @@ export const Step03_NavigateToAPIsTab: Story = {
     expect(catalogLink).toBeInTheDocument();
     expect(catalogLink.closest('a')).toHaveAttribute(
       'href',
-      'https://developers.redhat.com/api-catalog/'
+      'https://console.redhat.com/docs/api'
     );
 
     console.log('UJ: ✅ APIs tab opened with description and catalog link');


### PR DESCRIPTION
For [RHCLOUD-46939](https://redhat.atlassian.net/browse/RHCLOUD-46939). Updates the documentation link the API tab of the help panel to redirect to the internal console page instead of the external developer's site.

[RHCLOUD-46939]: https://redhat.atlassian.net/browse/RHCLOUD-46939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ