### PR TITLE
Point API doc links to console

### DIFF
--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.test.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
-import APIPanel from './APIPanel';
+import APIPanel, {
+  convertToConsoleDocsUrl,
+  getConsoleBaseUrl,
+} from './APIPanel';
 import {
   fetchBundleInfo,
   fetchBundles,
@@ -243,5 +246,115 @@ describe('APIPanel', () => {
 
     // No version in URL
     expect(screen.getByText('Cost-Management')).toBeInTheDocument();
+  });
+});
+
+describe('getConsoleBaseUrl', () => {
+  it('returns production URL for prod environment', () => {
+    expect(getConsoleBaseUrl('prod')).toBe('https://console.redhat.com');
+  });
+
+  it('returns stage URL for stage environment', () => {
+    expect(getConsoleBaseUrl('stage')).toBe('https://console.stage.redhat.com');
+  });
+
+  it('returns stage URL for frhStage environment', () => {
+    expect(getConsoleBaseUrl('frhStage')).toBe(
+      'https://console.stage.redhat.com'
+    );
+  });
+
+  it('returns production URL for qa environment (default)', () => {
+    expect(getConsoleBaseUrl('qa')).toBe('https://console.redhat.com');
+  });
+
+  it('returns production URL for ci environment (default)', () => {
+    expect(getConsoleBaseUrl('ci')).toBe('https://console.redhat.com');
+  });
+});
+
+describe('convertToConsoleDocsUrl', () => {
+  it('converts API name and version to console docs URL (production)', () => {
+    const result = convertToConsoleDocsUrl(
+      'notifications',
+      'https://developers.redhat.com/api-catalog/api/notifications/v2.0',
+      'prod'
+    );
+
+    expect(result).toBe('https://console.redhat.com/docs/api/notifications/v2');
+  });
+
+  it('converts API name and version to console docs URL (stage)', () => {
+    const result = convertToConsoleDocsUrl(
+      'notifications',
+      'https://developers.redhat.com/api-catalog/api/notifications/v2.0',
+      'stage'
+    );
+
+    expect(result).toBe(
+      'https://console.stage.redhat.com/docs/api/notifications/v2'
+    );
+  });
+
+  it('strips API suffix from name', () => {
+    const result = convertToConsoleDocsUrl(
+      'notifications api',
+      'https://developers.redhat.com/api-catalog/api/notifications/v1',
+      'prod'
+    );
+
+    expect(result).toBe('https://console.redhat.com/docs/api/notifications/v1');
+  });
+
+  it('handles APIs without version numbers', () => {
+    const result = convertToConsoleDocsUrl(
+      'advisor api',
+      'https://developers.redhat.com/api-catalog/api/advisor',
+      'prod'
+    );
+
+    expect(result).toBe('https://console.redhat.com/docs/api/advisor');
+  });
+
+  it('extracts only major version from v1.0', () => {
+    const result = convertToConsoleDocsUrl(
+      'notifications',
+      'https://developers.redhat.com/api-catalog/api/notifications/v1.0',
+      'prod'
+    );
+
+    expect(result).toBe('https://console.redhat.com/docs/api/notifications/v1');
+  });
+
+  it('extracts major version from v3.1.0', () => {
+    const result = convertToConsoleDocsUrl(
+      'sources',
+      'https://developers.redhat.com/api-catalog/api/sources/v3.1.0',
+      'prod'
+    );
+
+    expect(result).toBe('https://console.redhat.com/docs/api/sources/v3');
+  });
+
+  it('lowercases API name', () => {
+    const result = convertToConsoleDocsUrl(
+      'RBAC',
+      'https://developers.redhat.com/api-catalog/api/rbac/v1',
+      'prod'
+    );
+
+    expect(result).toBe('https://console.redhat.com/docs/api/rbac/v1');
+  });
+
+  it('handles frhStage environment correctly', () => {
+    const result = convertToConsoleDocsUrl(
+      'notifications',
+      'https://developers.redhat.com/api-catalog/api/notifications/v2.0',
+      'frhStage'
+    );
+
+    expect(result).toBe(
+      'https://console.stage.redhat.com/docs/api/notifications/v2'
+    );
   });
 });

--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
@@ -21,7 +21,6 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
@@ -134,6 +133,48 @@ const formatApiDisplayName = (name: string, url: string): string => {
   return version ? `${capitalizedName} ${version}` : capitalizedName;
 };
 
+/**
+ * Gets the base console URL based on the current environment
+ * Uses Chrome API's getEnvironment() to determine environment
+ * @param environment - Environment string from chrome.getEnvironment() ('prod', 'stage', 'qa', etc.)
+ * @returns Base console URL (e.g., "https://console.redhat.com" or "https://console.stage.redhat.com")
+ */
+export const getConsoleBaseUrl = (environment: string): string => {
+  // Stage environments (including frhStage for federal stage)
+  if (environment === 'stage' || environment === 'frhStage') {
+    return 'https://console.stage.redhat.com';
+  }
+
+  // Production (prod and all other environments default to production console)
+  return 'https://console.redhat.com';
+};
+
+/**
+ * Converts backend API URL to console docs URL (environment-aware)
+ * @param name - The raw API name (e.g., "notifications", "rbac")
+ * @param url - The backend URL to extract version from
+ * @param environment - Environment string from chrome.getEnvironment()
+ * @returns Console API docs URL (e.g., "https://console.redhat.com/docs/api/notifications/v2")
+ */
+export const convertToConsoleDocsUrl = (
+  name: string,
+  url: string,
+  environment: string
+): string => {
+  const nameWithoutApiSuffix = stripApiSuffix(name).toLowerCase();
+  const version = extractVersionFromUrl(url);
+  const baseUrl = getConsoleBaseUrl(environment);
+
+  if (version) {
+    // Remove decimal points from version (v1.0 → v1, v2.0 → v2)
+    const majorVersion = version.split('.')[0];
+    return `${baseUrl}/docs/api/${nameWithoutApiSuffix}/${majorVersion}`;
+  }
+
+  // Fallback if no version found
+  return `${baseUrl}/docs/api/${nameWithoutApiSuffix}`;
+};
+
 const mapBundleInfoWithTitles = async (): Promise<APIDoc[]> => {
   try {
     const [bundleInfoList, bundles] = await Promise.all([
@@ -191,8 +232,17 @@ const mapBundleInfoWithTitles = async (): Promise<APIDoc[]> => {
 };
 
 const APIResourceItem: React.FC<{ resource: APIDoc }> = ({ resource }) => {
+  const chrome = useChrome();
+
   const handleResourceClick = () => {
-    window.open(resource.url, '_blank', 'noopener,noreferrer');
+    const environment = chrome.getEnvironment();
+    const consoleDocsUrl = convertToConsoleDocsUrl(
+      resource.name,
+      resource.url,
+      environment
+    );
+    // Navigate within the same page (keeps help panel open)
+    window.location.href = consoleDocsUrl;
   };
 
   return (
@@ -213,8 +263,6 @@ const APIResourceItem: React.FC<{ resource: APIDoc }> = ({ resource }) => {
               onClick={handleResourceClick}
               isInline
               className="pf-v6-u-text-align-left pf-v6-u-p-0"
-              icon={<ExternalLinkAltIcon />}
-              iconPosition="end"
             >
               {resource.displayName}
             </Button>


### PR DESCRIPTION
For [RHCLOUD-46940](https://redhat.atlassian.net/browse/RHCLOUD-46940). Changes the API doc links from an external developer link (and removes the external link icon) to point to the internal console API doc page.

https://github.com/user-attachments/assets/a36ece46-9064-405f-982d-b42d78d19f26



[RHCLOUD-46940]: https://redhat.atlassian.net/browse/RHCLOUD-46940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ