### PR TITLE
feat: add unique OUIA ID to feedback home title

### DIFF
--- a/src/components/HelpPanel/HelpPanelTabs/Feedback/FeedbackPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/Feedback/FeedbackPanel.tsx
@@ -130,7 +130,11 @@ const FeedbackPanel: React.FC<SubTabProps> = ({ setNewActionTitle }) => {
           <Stack hasGutter>
             <StackItem>
               <Content>
-                <Content component={ContentVariants.h1}>
+                <Content
+                  component={ContentVariants.h1}
+                  ouiaId="feedback-home-title"
+                  ouiaSafe
+                >
                   {intl.formatMessage(messages.tellAboutExperience)}
                 </Content>
                 <Content component="p">


### PR DESCRIPTION
## Summary

Adds unique OUIA component ID to the feedback home page title to enable reliable test automation.

## Changes

Added `data-ouia-component-id="feedback-home-title"` to the "Tell us about your experience" heading in the feedback home page.

## Problem Solved

Prevents strict mode violations in Playwright tests caused by duplicate auto-generated OUIA IDs:
- Before: `OUIA-Generated-Content-14` and `OUIA-Generated-Content-3` (duplicates)
- After: `feedback-home-title` (unique, stable ID)

## Testing

Enables tests to use:
```typescript
page.locator('[data-ouia-component-id="feedback-home-title"]')
```

Instead of:
```typescript
page.getByText('Tell us about your experience') // causes strict mode error
```

## Related

Required for feedback test migration PR #305