### PR TITLE
Add PF6 background color override for help panel

### DIFF
--- a/src/components/HelpPanel/HelpPanelContent.tsx
+++ b/src/components/HelpPanel/HelpPanelContent.tsx
@@ -36,7 +36,7 @@ const HelpPanelContent = ({
 
   return (
     <>
-      <DrawerHead>
+      <DrawerHead className="lr-c-help-panel-background-override">
         <Title headingLevel="h2" data-ouia-component-id="help-panel-title">
           Help
         </Title>
@@ -61,7 +61,7 @@ const HelpPanelContent = ({
           />
         </DrawerActions>
       </DrawerHead>
-      <DrawerPanelBody>
+      <DrawerPanelBody className="lr-c-help-panel-background-override">
         <HelpPanelCustomTabs ref={tabsRef} />
       </DrawerPanelBody>
     </>

--- a/src/components/HelpPanel/HelpPanelCustomTabs.scss
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.scss
@@ -1,25 +1,7 @@
 // Help panel is rendered inside the platform's notification drawer with class "learningResources".
-// Override the notification drawer and its parent panel background so the whole drawer is white.
-// :global() is needed because the drawer is rendered by chrome outside our app's DOM tree (no .learning-resources parent).
-
-// The panel wrapper that contains the notification drawer
-:global(.pf-v6-c-drawer__panel:has(> .learningResources)),
-:global(.pf-v5-c-drawer__panel:has(> .learningResources)) {
-  background-color: var(--pf-t--global--background--color--primary--default);
-}
-
-// The notification drawer itself
-:global(.pf-v6-c-notification-drawer.learningResources),
-:global(.pf-v5-c-notification-drawer.learningResources) {
-  background-color: var(--pf-t--global--background--color--primary--default);
-}
-
-// Top of Help panel drawer only: header (Help title, Ask Red Hat, close). Do not scope
-// quickstart drawer head (inside tab content), which should keep PatternFly's blue header.
-// Note: DrawerHead is nested inside the notification drawer, which is inside the panel.
-:global(.pf-v6-c-notification-drawer.learningResources > .pf-v6-c-drawer__head),
-:global(.pf-v5-c-notification-drawer.learningResources > .pf-v6-c-drawer__head) {
-  background-color: var(--pf-t--global--background--color--primary--default);
+// Custom background override needed because prod has both PF5 and PF6, causing version conflicts.
+.lr-c-help-panel-background-override {
+  background-color: var(--pf-v6-c-notification-drawer--BackgroundColor) !important;
 }
 
 // Wrapper so tab list and tab content sections can share height; tab content gets remaining space.


### PR DESCRIPTION
After debugging with Martin, we discovered the discrepancy between stage and prod came from PF5 still being enabled in prod while stage is PF6 only. This custom class should ignore those overrides happening on prod and correctly show the background color.