### PR TITLE
Help panel SPUR tweaks

### DIFF
--- a/cypress/component/HelpPanel.cy.tsx
+++ b/cypress/component/HelpPanel.cy.tsx
@@ -45,6 +45,7 @@ const Wrapper = ({ children, flags = defaultFlags, api }: { children: React.Reac
         bundleTitle: 'RHEL',
       }),
       getAvailableBundles: () => [],
+      getEnvironment: () => 'stage',
       chromeHistory: { push: () => {}, replace: () => {} },
       auth: {
         getUser: () => Promise.resolve({
@@ -168,6 +169,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       chromeHistory: { push: () => {}, replace: () => {} },
+      getEnvironment: () => 'stage',
     } as any);
     cy.mount(
       <Wrapper>
@@ -223,6 +225,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       getAvailableBundles: () => [{ id: 'rhel', title: 'RHEL' }],
+      getEnvironment: () => 'stage',
     } as any);
 
     cy.mount(
@@ -293,6 +296,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       chromeHistory: { push: () => {}, replace: () => {} },
+      getEnvironment: () => 'stage',
     } as any);
     cy.mount(
       <Wrapper>
@@ -326,6 +330,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       chromeHistory: { push: () => {}, replace: () => {} },
+      getEnvironment: () => 'stage',
     } as any);
 
     cy.mount(
@@ -346,6 +351,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       chromeHistory: { push: () => {}, replace: () => {} },
+      getEnvironment: () => 'stage',
     } as any);
 
     cy.mount(
@@ -399,6 +405,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       getAvailableBundles: () => [],
+      getEnvironment: () => 'stage',
       chromeHistory: { push: () => {}, replace: () => {} },
       auth: {
         getUser: () => Promise.resolve({
@@ -533,6 +540,7 @@ describe('HelpPanel', () => {
         bundleId: 'rhel',
         bundleTitle: 'RHEL',
       }),
+      getEnvironment: () => 'stage',
       auth: {
         getUser: () => Promise.resolve({
           identity: {
@@ -571,6 +579,7 @@ describe('HelpPanel', () => {
         bundleId: 'rhel',
         bundleTitle: 'RHEL',
       }),
+      getEnvironment: () => 'stage',
       auth: {
         getUser: () => Promise.resolve({
           identity: {
@@ -624,6 +633,7 @@ describe('HelpPanel', () => {
         bundleId: 'rhel',
         bundleTitle: 'RHEL',
       }),
+      getEnvironment: () => 'stage',
       auth: {
         getUser: () => Promise.resolve({
           identity: {
@@ -677,6 +687,7 @@ describe('HelpPanel', () => {
         bundleTitle: 'RHEL',
       }),
       chromeHistory: { push: () => {}, replace: () => {} },
+      getEnvironment: () => 'stage',
     } as any);
 
     cy.mount(
@@ -789,6 +800,7 @@ describe('HelpPanel', () => {
           { id: 'rhel', title: 'RHEL' },
           { id: 'openshift', title: 'OpenShift' },
         ],
+        getEnvironment: () => 'stage',
         auth: {
           getUser: () => Promise.resolve(mockAuthUser),
           getToken: () => Promise.resolve('mock-token'),

--- a/src/components/HelpPanel/HelpPanelCustomTabs.scss
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.scss
@@ -145,3 +145,8 @@
   min-height: 0;
   height: 100%;
 }
+
+// Hide chatbot header when embedded in help panel
+.lr-c-help-panel-tabs-wrapper .pf-chatbot__header {
+  display: none;
+}

--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
@@ -29,7 +29,6 @@ import {
   fetchBundles,
 } from '../../../utils/fetchBundleInfoAPI';
 import { getBundleDisplayName } from '../../../utils/bundleUtils';
-import useNavigateKeepPanel from '../../../hooks/useNavigateKeepPanel';
 
 interface APIDoc {
   name: string;
@@ -234,27 +233,10 @@ const mapBundleInfoWithTitles = async (): Promise<APIDoc[]> => {
 
 const APIResourceItem: React.FC<{ resource: APIDoc }> = ({ resource }) => {
   const chrome = useChrome();
-  const navigateKeepPanel = useNavigateKeepPanel();
 
-  const handleResourceClick = () => {
+  const getConsoleDocsUrl = () => {
     const environment = chrome.getEnvironment();
-    const consoleDocsUrl = convertToConsoleDocsUrl(
-      resource.name,
-      resource.url,
-      environment
-    );
-    // Use client-side navigation to preserve help panel state
-    try {
-      const url = new URL(consoleDocsUrl);
-      const target = `${url.pathname}${url.search}${url.hash}`;
-      if (url.origin === window.location.origin) {
-        navigateKeepPanel(target);
-      } else {
-        window.location.assign(consoleDocsUrl);
-      }
-    } catch {
-      navigateKeepPanel(consoleDocsUrl);
-    }
+    return convertToConsoleDocsUrl(resource.name, resource.url, environment);
   };
 
   return (
@@ -272,7 +254,8 @@ const APIResourceItem: React.FC<{ resource: APIDoc }> = ({ resource }) => {
           <FlexItem>
             <Button
               variant="link"
-              onClick={handleResourceClick}
+              component="a"
+              href={getConsoleDocsUrl()}
               isInline
               className="pf-v6-u-text-align-left pf-v6-u-p-0"
             >
@@ -299,7 +282,6 @@ const APIResourceItem: React.FC<{ resource: APIDoc }> = ({ resource }) => {
 const APIPanelContent: React.FC = () => {
   const intl = useIntl();
   const chrome = useChrome();
-  const navigateKeepPanel = useNavigateKeepPanel();
   const [activeToggle, setActiveToggle] = useState<string>('all');
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -387,10 +369,6 @@ const APIPanelContent: React.FC = () => {
             component="a"
             href="/docs/api"
             data-ouia-component-id="help-panel-api-docs-link"
-            onClick={(e: React.MouseEvent) => {
-              e.preventDefault();
-              navigateKeepPanel('/docs/api');
-            }}
             isInline
           >
             {intl.formatMessage(messages.apiDocumentationCatalogLinkText)}

--- a/src/components/HelpPanel/HelpPanelTabs/Feedback/FeedbackPanel.scss
+++ b/src/components/HelpPanel/HelpPanelTabs/Feedback/FeedbackPanel.scss
@@ -29,3 +29,6 @@
   margin-left: 4px;
 }
 
+.feedback-card .pf-v6-c-card__body {
+  padding-bottom: var(--pf-t--global--spacer--md);
+}

--- a/src/components/HelpPanel/HelpPanelTabs/HelpPanelTabContainer.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/HelpPanelTabContainer.tsx
@@ -14,11 +14,15 @@ const HelpPanelTabContainer = ({
     return helpPanelTabsMapper[activeTabType];
   }, [activeTabType]);
 
+  // VA tab should fill the entire panel without padding
+  const shouldRemovePadding = activeTabType === TabType.va;
+  const containerClassName = shouldRemovePadding ? '' : 'pf-v6-u-p-md';
+
   // If custom content is provided, render it directly
   if (customContent) {
     return (
       <div
-        className="pf-v6-u-p-md"
+        className={containerClassName}
         data-ouia-component-id="help-panel-content-container"
       >
         {customContent}
@@ -29,7 +33,7 @@ const HelpPanelTabContainer = ({
   // Otherwise, render the standard tab component
   return (
     <div
-      className="pf-v6-u-p-md"
+      className={containerClassName}
       data-ouia-component-id="help-panel-content-container"
     >
       <ActiveComponent setNewActionTitle={setNewActionTitle} />

--- a/src/components/HelpPanel/HelpPanelTabs/VAPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/VAPanel.tsx
@@ -15,7 +15,7 @@ const VAErrorElement: React.FC = () => {
   console.error('VA Panel: Virtual Assistant module failed to load');
 
   return (
-    <Stack hasGutter className="pf-v6-u-h-100">
+    <Stack className="pf-v6-u-h-100 pf-v6-u-p-md">
       <StackItem>
         <Content>
           {intl.formatMessage(messages.virtualAssistantNotAvailable)}
@@ -32,26 +32,17 @@ const VAPanel: React.FC<{
     scope: 'virtualAssistant',
     module: './VAEmbed',
     fallback: (
-      <Stack hasGutter className="pf-v6-u-h-100">
-        <StackItem
-          isFilled
-          className="pf-v6-u-display-flex pf-v6-u-justify-content-center pf-v6-u-align-items-center"
-        >
-          <Spinner size="lg" />
-        </StackItem>
-      </Stack>
+      <div className="pf-v6-u-h-100 pf-v6-u-display-flex pf-v6-u-justify-content-center pf-v6-u-align-items-center">
+        <Spinner size="lg" />
+      </div>
     ),
     ErrorComponent: <VAErrorElement />,
   };
 
   return (
-    <Stack hasGutter className="pf-v6-u-h-100">
-      <StackItem isFilled className="pf-v6-u-overflow-hidden">
-        <div className="pf-v6-u-h-100 pf-v6-u-overflow-y-auto">
-          <ScalprumComponent {...virtualAssistantProps} />
-        </div>
-      </StackItem>
-    </Stack>
+    <div className="pf-v6-u-h-100">
+      <ScalprumComponent {...virtualAssistantProps} />
+    </div>
   );
 };
 

--- a/src/user-journeys/HelpPanelAPIPanel.stories.tsx
+++ b/src/user-journeys/HelpPanelAPIPanel.stories.tsx
@@ -119,7 +119,7 @@ export const Step04_ViewAPIDocsList: Story = {
     // Wait for API data to load asynchronously
     await waitFor(
       () => {
-        const advisorLink = canvas.queryByRole('button', { name: /Advisor/i });
+        const advisorLink = canvas.queryByRole('link', { name: /Advisor/i });
         expect(advisorLink).toBeInTheDocument();
       },
       { timeout: TEST_TIMEOUTS.ELEMENT_WAIT }
@@ -217,7 +217,7 @@ export const Step06_VerifyExternalLinks: Story = {
 
     await waitFor(
       () => {
-        const advisorLink = canvas.getByRole('button', {
+        const advisorLink = canvas.getByRole('link', {
           name: /Advisor/i,
         });
         expect(advisorLink).toBeInTheDocument();
@@ -241,7 +241,7 @@ export const Step06_VerifyExternalLinks: Story = {
     ];
 
     for (const apiName of expectedAPIs) {
-      const link = canvas.getByRole('button', { name: new RegExp(apiName) });
+      const link = canvas.getByRole('link', { name: new RegExp(apiName) });
       expect(link).toBeInTheDocument();
     }
 


### PR DESCRIPTION
- Hides the header in the chatbot panel and extends its view to the entire panel
- Reverts the doc link changes in the API tab that prevents users from clicking between docs
- Updates the feedback panel card padding for the bottom of the card and the text