### PR TITLE
fix(text-field): Fix issue where text-field spazzes out on input

### DIFF
--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -354,7 +354,7 @@ const CreatorWizard = ({
         work_check_help: t.review?.failedTaskHelp,
       })),
     };
-  }, [quickStart, currentKind, currentBundles, currentTags]);
+  }, [viewMode]);
 
   // Update stage when switching to creator mode to show preview
   const handleViewModeChange = (newMode: ViewMode) => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->
The creator wizard text fields (title, description, etc.) were "spazzing out". This included card preview flickering and field flickering. The root cause was a useMemo array which was running on each input change, causing re-renders. 

Fixed this by using the existing viewMode, this makes it only recompute when switching between the wizard and creator tabs/modes.


[RHCLOUD-48575](https://redhat.atlassian.net/browse/RHCLOUD-48575)

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:
Hard to see due to flicker, but preview card on the right is different wording as it flickers through)
<img width="1024" height="566" alt="image" src="https://github.com/user-attachments/assets/eb61c33a-9a93-4194-94f0-0cb511ddf6eb" />

#### After:
<img width="1834" height="974" alt="image" src="https://github.com/user-attachments/assets/20da3927-832a-48b2-8758-d7df50755399" />

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [X] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [X] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code


[RHCLOUD-48575]: https://redhat.atlassian.net/browse/RHCLOUD-48575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ