### PR TITLE
fix(url-input): Fix any inputs causing url field to error out

### DIFF
--- a/src/components/creator/CreatorWizard.test.tsx
+++ b/src/components/creator/CreatorWizard.test.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import CreatorWizard, { CreatorWizardProps } from './CreatorWizard';
+import { ExtendedQuickstart } from '../../utils/fetchQuickstarts';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  useChrome: () => ({
+    getAvailableBundles: () => [],
+    getBundle: () => '',
+    quickStarts: { set: jest.fn() },
+  }),
+}));
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/helpers',
+  () => ({ downloadFile: jest.fn() })
+);
+
+jest.mock('./CreatorYAMLView', () => {
+  const Mock = () => <div data-testid="yaml-view" />;
+  Mock.displayName = 'MockYAMLView';
+  return { __esModule: true, default: Mock };
+});
+
+let capturedInitialValues: Record<string, unknown> | undefined;
+let capturedOnChangeSpec: jest.Mock;
+
+jest.mock('@data-driven-forms/react-form-renderer', () => {
+  const actual = jest.requireActual('@data-driven-forms/react-form-renderer');
+  return {
+    ...actual,
+    FormRenderer: (props: {
+      initialValues?: Record<string, unknown>;
+      children: (opts: { formFields: React.ReactNode }) => React.ReactNode;
+    }) => {
+      capturedInitialValues = props.initialValues;
+      return (
+        <div data-testid="mock-form-renderer">
+          {props.children?.({ formFields: null })}
+        </div>
+      );
+    },
+    FormSpy: ({
+      children,
+    }: {
+      children?: (state: {
+        values: Record<string, unknown>;
+      }) => React.ReactNode;
+    }) => {
+      return children?.({ values: capturedInitialValues ?? {} }) ?? null;
+    },
+  };
+});
+
+jest.mock('@data-driven-forms/pf4-component-mapper/component-mapper', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+const makeQS = (
+  overrides: Partial<ExtendedQuickstart['spec']> = {}
+): ExtendedQuickstart => ({
+  metadata: { name: 'test-qs', tags: [] },
+  spec: {
+    displayName: 'Test QS',
+    description: 'A test quickstart',
+    icon: null,
+    ...overrides,
+  },
+});
+
+const makeProps = (
+  overrides: Partial<CreatorWizardProps> = {}
+): CreatorWizardProps => {
+  capturedOnChangeSpec = jest.fn();
+  return {
+    onChangeKind: jest.fn(),
+    onChangeQuickStartSpec: capturedOnChangeSpec,
+    onChangeBundles: jest.fn(),
+    onChangeCurrentStage: jest.fn(),
+    resetCreator: jest.fn(),
+    onChangeTags: jest.fn(),
+    onChangeMetadataTags: jest.fn(),
+    files: [],
+    filterData: { categories: [] },
+    quickStart: makeQS(),
+    currentBundles: [],
+    currentTags: {},
+    currentKind: null,
+    ...overrides,
+  };
+};
+
+describe('CreatorWizard', () => {
+  beforeEach(() => {
+    capturedInitialValues = undefined;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('field stability (no spazzing on input)', () => {
+    it('does not recompute initialValues when quickStart prop changes', () => {
+      const props = makeProps({
+        quickStart: makeQS({ displayName: 'Original' }),
+      });
+      const { rerender } = render(<CreatorWizard {...props} />);
+      const first = capturedInitialValues;
+
+      rerender(
+        <CreatorWizard
+          {...props}
+          quickStart={makeQS({ displayName: 'Changed' })}
+        />
+      );
+
+      expect(capturedInitialValues).toBe(first);
+      expect(capturedInitialValues?.title).toBe('Original');
+    });
+
+    it('does not recompute initialValues when currentKind/bundles/tags change', () => {
+      const props = makeProps();
+      const { rerender } = render(<CreatorWizard {...props} />);
+      const first = capturedInitialValues;
+
+      rerender(
+        <CreatorWizard
+          {...props}
+          currentKind="documentation"
+          currentBundles={['insights']}
+          currentTags={{ content: ['quickstart'] }}
+        />
+      );
+
+      expect(capturedInitialValues).toBe(first);
+    });
+
+    it('recomputes initialValues when switching wizard <-> YAML', async () => {
+      const props = makeProps({
+        quickStart: makeQS({ displayName: 'Before' }),
+      });
+      const { rerender } = render(<CreatorWizard {...props} />);
+      expect(capturedInitialValues?.title).toBe('Before');
+
+      act(() => {
+        screen.getByRole('tab', { name: /creator/i }).click();
+      });
+
+      rerender(
+        <CreatorWizard
+          {...props}
+          quickStart={makeQS({ displayName: 'After' })}
+        />
+      );
+
+      act(() => {
+        screen.getByRole('tab', { name: /wizard/i }).click();
+      });
+
+      await waitFor(() => {
+        expect(capturedInitialValues?.title).toBe('After');
+      });
+    });
+  });
+
+  describe('URL field does not error on normal input', () => {
+    it('sets link for a valid URL', async () => {
+      render(
+        <CreatorWizard
+          {...makeProps({
+            quickStart: makeQS({
+              link: { text: 'Docs', href: 'https://docs.redhat.com' },
+            }),
+            currentKind: 'documentation',
+          })}
+        />
+      );
+
+      await waitFor(() => {
+        expect(capturedOnChangeSpec).toHaveBeenCalledWith(
+          expect.objectContaining({
+            link: expect.objectContaining({
+              href: 'https://docs.redhat.com',
+            }),
+          })
+        );
+      });
+    });
+
+    it('does not set link for partial/invalid URL input', async () => {
+      render(
+        <CreatorWizard
+          {...makeProps({
+            quickStart: makeQS({
+              link: { text: 'Docs', href: 'not-a-url' },
+            }),
+            currentKind: 'documentation',
+          })}
+        />
+      );
+
+      await waitFor(() => {
+        expect(capturedOnChangeSpec).toHaveBeenCalledWith(
+          expect.objectContaining({ link: undefined })
+        );
+      });
+    });
+
+    it('does not set link when URL field is empty', async () => {
+      render(
+        <CreatorWizard
+          {...makeProps({
+            quickStart: makeQS(),
+            currentKind: 'documentation',
+          })}
+        />
+      );
+
+      await waitFor(() => {
+        expect(capturedOnChangeSpec).toHaveBeenCalledWith(
+          expect.objectContaining({ link: undefined })
+        );
+      });
+    });
+  });
+});

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -354,7 +354,7 @@ const CreatorWizard = ({
         work_check_help: t.review?.failedTaskHelp,
       })),
     };
-  }, [quickStart, currentKind, currentBundles, currentTags]);
+  }, [viewMode]);
 
   // Update stage when switching to creator mode to show preview
   const handleViewModeChange = (newMode: ViewMode) => {

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -98,8 +98,13 @@ type FormTaskValue = {
 };
 
 const isValidUrl = (s: string): boolean => {
-  try { new URL(s); return true; } catch { return false; }
-}
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 const PropUpdater = ({
   values,
@@ -191,6 +196,7 @@ const PropUpdater = ({
       tasks: effectiveTasks,
     });
 
+    onChangeKind(kind);
   }, [
     meta,
     rawKind,
@@ -332,9 +338,9 @@ const CreatorWizard = ({
   const schema = useMemo(() => makeSchema(chrome, filterData), []);
   const availableBundles = useMemo(() => chrome.getAvailableBundles(), []);
 
-  // Derive initialValues from shared state so wizard ↔ YAML stays in sync.
-  // FormRenderer is conditionally rendered (unmounted in YAML mode), so it
-  // picks up fresh initialValues each time the user switches back to wizard.
+  // [viewMode] only, including props like quickStart, currentKind, etc would recompute on
+  // every keystroke and cause fields to spazz/lose focus. FormRenderer is unmounted in YAML
+  // mode, so switching back triggers a remount with fresh initialValues anyway.
   const initialValues = useMemo(() => {
     if (!quickStart) return undefined;
     return {

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -97,6 +97,10 @@ type FormTaskValue = {
   work_check_help?: string;
 };
 
+const isValidUrl = (s: string): boolean => {
+  try { new URL(s); return true; } catch { return false; }
+}
+
 const PropUpdater = ({
   values,
   onChangeKind,
@@ -172,7 +176,7 @@ const PropUpdater = ({
       description: description ?? '',
       icon: null,
       link:
-        meta?.fields?.url && url !== undefined
+        meta?.fields?.url && url !== undefined && isValidUrl(url)
           ? {
               text: 'View documentation',
               href: url,
@@ -187,7 +191,6 @@ const PropUpdater = ({
       tasks: effectiveTasks,
     });
 
-    onChangeKind(kind);
   }, [
     meta,
     rawKind,

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -99,8 +99,8 @@ type FormTaskValue = {
 
 const isValidUrl = (s: string): boolean => {
   try {
-    new URL(s);
-    return true;
+    const { protocol } = new URL(s);
+    return protocol === 'http:' || protocol === 'https:';
   } catch {
     return false;
   }


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->
The URL Endpoint input field threw an error on any input. This didn't allow users to type out any full links (had to copy and paste working URL in one shot).  This PR also builds on #339 (please merge first) which updated the viewMode. Now the input allows users to type anything until a URL is actually valid without throwing an error.

[RHCLOUD-48617](https://redhat.atlassian.net/browse/RHCLOUD-48617)

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:
(Usually did whats in the image or go back one page on any input unless copy pasted full URL)
<img width="756" height="324" alt="image" src="https://github.com/user-attachments/assets/dc11fbe4-4449-443a-9371-334519f73d51" />

#### After:
<img width="601" height="269" alt="image" src="https://github.com/user-attachments/assets/aa4d8b22-5432-40f0-bcdf-004fd14caf38" />

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->
This PR is dependent on PR #339 (spazzing-text-field) branch, please merge that one first.
---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code

[RHCLOUD-48617]: https://redhat.atlassian.net/browse/RHCLOUD-48617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ