### PR TITLE
feat: add fuzzy search to API documentation panel using useOramaSearc…

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -44,6 +44,10 @@ const config: StorybookConfig = {
           process.cwd(),
           '.storybook/hooks/scalprum.js'
         ),
+        'chrome/search/useOramaSearch': path.resolve(
+          process.cwd(),
+          'src/__mocks__/chrome/search/useOramaSearch.ts'
+        ),
       },
     };
 

--- a/config/webpack.cy.js
+++ b/config/webpack.cy.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const { ModuleFederationPlugin } = require('webpack').container;
 
@@ -41,6 +42,9 @@ const config = {
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    alias: {
+      'chrome/search/useOramaSearch': path.resolve(__dirname, '../src/__mocks__/chrome/search/useOramaSearch.ts'),
+    },
   },
   plugins: [
     new MiniCssExtractPlugin(),

--- a/fec.config.js
+++ b/fec.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { NormalModuleReplacementPlugin } = require('webpack');
 
 module.exports = {
   appUrl: [
@@ -25,7 +26,12 @@ module.exports = {
    * Add additional webpack plugins
    */
   frontendCRDPath: path.resolve(__dirname, './deploy/frontend.yml'),
-  plugins: [],
+  plugins: [
+    new NormalModuleReplacementPlugin(
+      /^chrome\/search\/useOramaSearch$/,
+      path.resolve(__dirname, 'src/__mocks__/chrome/search/useOramaSearch.ts')
+    ),
+  ],
   moduleFederation: {
     exposes: {
       './RootApp': path.resolve(__dirname, './src/AppEntry.tsx'),

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -2,3 +2,30 @@ declare module '*.svg' {
   const content: string;
   export default content;
 }
+
+declare module 'chrome/search/useOramaSearch' {
+  interface UseOramaSearchOptions {
+    threshold?: number;
+    tolerance?: number;
+    limit?: number;
+    properties?: string[];
+    boost?: Record<string, number>;
+  }
+
+  interface OramaSearchResult<T> {
+    id: string;
+    score: number;
+    document: T;
+  }
+
+  export default function useOramaSearch<T>(
+    data: T[] | undefined,
+    schema: Record<string, 'string' | 'string[]' | 'number' | 'boolean'>
+  ): {
+    query: (
+      term: string,
+      options?: UseOramaSearchOptions
+    ) => Promise<OramaSearchResult<T>[]>;
+    isReady: boolean;
+  };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   roots: ['<rootDir>/src/'],
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',
+    '^chrome/(.*)$': '<rootDir>/src/__mocks__/chrome/$1',
   },
   transformIgnorePatterns,
   setupFilesAfterEnv: ['<rootDir>/config/jest.setup.js'],

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -124,6 +124,10 @@ const messages = defineMessages({
     id: 'helpPanel.api.noDocsFound',
     defaultMessage: 'No API documentation found matching your criteria.',
   },
+  apiSearchPlaceholder: {
+    id: 'helpPanel.api.searchPlaceholder',
+    defaultMessage: 'Search API documentation',
+  },
 
   // Support Panel
   noOpenSupportCasesTitle: {

--- a/src/__mocks__/chrome/search/useOramaSearch.ts
+++ b/src/__mocks__/chrome/search/useOramaSearch.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface OramaSearchResult<T> {
+  id: string;
+  score: number;
+  document: T;
+}
+
+function useOramaSearch<T extends Record<string, unknown>>(
+  data: T[] | undefined,
+  schema: Record<string, 'string' | 'string[]' | 'number' | 'boolean'>
+) {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    setIsReady(!!data?.length);
+  }, [data]);
+
+  const query = useCallback(
+    async (term: string): Promise<OramaSearchResult<T>[]> => {
+      if (!data?.length || !term.trim()) return [];
+      const lower = term.toLowerCase();
+      const stringFields = Object.entries(schema)
+        .filter(([, type]) => type === 'string' || type === 'string[]')
+        .map(([key]) => key);
+
+      return data
+        .filter((item) =>
+          stringFields.some((field) => {
+            const value = item[field];
+            if (Array.isArray(value)) {
+              return value.some(
+                (v) => typeof v === 'string' && v.toLowerCase().includes(lower)
+              );
+            }
+            return (
+              typeof value === 'string' && value.toLowerCase().includes(lower)
+            );
+          })
+        )
+        .map((item, i) => ({ id: String(i), score: 1, document: item }));
+    },
+    [data, schema]
+  );
+
+  return { query, isReady };
+}
+
+export default useOramaSearch;

--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.test.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import APIPanel, {
   convertToConsoleDocsUrl,
@@ -12,6 +18,17 @@ import {
 
 // Mock the fetch functions
 jest.mock('../../../utils/fetchBundleInfoAPI');
+
+// Mock useOramaSearch hook
+const mockQuery = jest.fn().mockResolvedValue([]);
+const mockUseOramaSearch = jest.fn(() => ({
+  query: mockQuery,
+  isReady: true,
+}));
+jest.mock('chrome/search/useOramaSearch', () => ({
+  __esModule: true,
+  default: () => mockUseOramaSearch(),
+}));
 
 // Mock useChrome hook
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -248,6 +265,265 @@ describe('APIPanel', () => {
 
     // No version in URL
     expect(screen.getByText('Cost-Management')).toBeInTheDocument();
+  });
+});
+
+describe('APIPanel search', () => {
+  const mockSetNewActionTitle = jest.fn();
+
+  const sampleBundleInfo = [
+    {
+      bundleLabels: ['insights'],
+      frontendName: 'notifications',
+      url: 'https://developers.redhat.com/api-catalog/api/notifications/v1',
+    },
+    {
+      bundleLabels: ['insights'],
+      frontendName: 'advisor',
+      url: 'https://developers.redhat.com/api-catalog/api/advisor/v2',
+    },
+    {
+      bundleLabels: ['openshift'],
+      frontendName: 'cost-management',
+      url: 'https://developers.redhat.com/api-catalog/api/cost-management/v1',
+    },
+  ];
+
+  const sampleBundles = [
+    { id: 'insights', title: 'RHEL', navItems: [] },
+    { id: 'openshift', title: 'OpenShift', navItems: [] },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockQuery.mockResolvedValue([]);
+    mockFetchBundleInfo.mockResolvedValue(sampleBundleInfo);
+    mockFetchBundles.mockResolvedValue(sampleBundles);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders search input', async () => {
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('Search API documentation')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('calls query with debounced search text', async () => {
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search API documentation');
+    fireEvent.change(searchInput, { target: { value: 'notif' } });
+
+    expect(mockQuery).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalledWith('notif');
+    });
+  });
+
+  it('displays search results when query returns matches', async () => {
+    mockQuery.mockResolvedValue([
+      {
+        id: '1',
+        score: 0.9,
+        document: {
+          name: 'notifications',
+          displayName: 'Notifications v1',
+          services: ['RHEL'],
+          url: 'https://developers.redhat.com/api-catalog/api/notifications/v1',
+        },
+      },
+    ]);
+
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search API documentation');
+    fireEvent.change(searchInput, { target: { value: 'notif' } });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+      expect(screen.getByText(/API Documentation \(1\)/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when search returns no results', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search API documentation');
+    fireEvent.change(searchInput, { target: { value: 'zzzznonexistent' } });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No API documentation found matching your criteria/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows all items when search is cleared', async () => {
+    mockQuery.mockResolvedValue([
+      {
+        id: '1',
+        score: 0.9,
+        document: {
+          name: 'notifications',
+          displayName: 'Notifications v1',
+          services: ['RHEL'],
+          url: 'https://developers.redhat.com/api-catalog/api/notifications/v1',
+        },
+      },
+    ]);
+
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/API Documentation \(3\)/i)).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search API documentation');
+    fireEvent.change(searchInput, { target: { value: 'notif' } });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/API Documentation \(1\)/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/API Documentation \(3\)/i)).toBeInTheDocument();
+    });
+  });
+
+  it('filters search results by bundle toggle', async () => {
+    mockQuery.mockResolvedValue([
+      {
+        id: '1',
+        score: 0.9,
+        document: {
+          name: 'notifications',
+          displayName: 'Notifications v1',
+          services: ['RHEL'],
+          url: 'https://developers.redhat.com/api-catalog/api/notifications/v1',
+        },
+      },
+      {
+        id: '2',
+        score: 0.7,
+        document: {
+          name: 'cost-management',
+          displayName: 'Cost-Management v1',
+          services: ['OpenShift'],
+          url: 'https://developers.redhat.com/api-catalog/api/cost-management/v1',
+        },
+      },
+    ]);
+
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+    });
+
+    // Activate bundle toggle (mocked as "insights" → display name "RHEL")
+    const bundleToggle = screen.getByRole('button', { name: 'RHEL' });
+    fireEvent.click(bundleToggle);
+
+    // Search while bundle filter is active
+    const searchInput = screen.getByPlaceholderText('Search API documentation');
+    fireEvent.change(searchInput, { target: { value: 'management' } });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Search returned both, but bundle filter keeps only the RHEL one
+    await waitFor(() => {
+      expect(screen.getByText(/API Documentation \(1\)/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+    expect(screen.queryByText('Cost-Management v1')).not.toBeInTheDocument();
+  });
+
+  it('calls setNewActionTitle on search change', async () => {
+    render(
+      <IntlProvider locale="en" defaultLocale="en">
+        <APIPanel setNewActionTitle={mockSetNewActionTitle} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications v1')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search API documentation');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+
+    expect(mockSetNewActionTitle).toHaveBeenCalledWith('test');
   });
 });
 

--- a/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
+++ b/src/components/HelpPanel/HelpPanelTabs/APIPanel.tsx
@@ -12,6 +12,7 @@ import {
   Label,
   Pagination,
   PaginationProps,
+  SearchInput,
   Spinner,
   Stack,
   StackItem,
@@ -23,6 +24,7 @@ import {
 } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useIntl } from 'react-intl';
+import useOramaSearch from 'chrome/search/useOramaSearch';
 import messages from '../../../Messages';
 import {
   fetchBundleInfo,
@@ -175,6 +177,23 @@ export const convertToConsoleDocsUrl = (
   return `${baseUrl}/docs/api/${nameWithoutApiSuffix}`;
 };
 
+const useDebounce = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+};
+
+const API_SEARCH_SCHEMA = {
+  name: 'string' as const,
+  displayName: 'string' as const,
+  services: 'string[]' as const,
+};
+
 const mapBundleInfoWithTitles = async (): Promise<APIDoc[]> => {
   try {
     const [bundleInfoList, bundles] = await Promise.all([
@@ -279,13 +298,19 @@ const APIResourceItem: React.FC<{ resource: APIDoc }> = ({ resource }) => {
   );
 };
 
-const APIPanelContent: React.FC = () => {
+const APIPanelContent: React.FC<{
+  setNewActionTitle: (title: string) => void;
+}> = ({ setNewActionTitle }) => {
   const intl = useIntl();
   const chrome = useChrome();
   const [activeToggle, setActiveToggle] = useState<string>('all');
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [apiDocs, setApiDocs] = useState<APIDoc[]>([]);
+  const [searchText, setSearchText] = useState('');
+  const [searchResults, setSearchResults] = useState<APIDoc[] | null>(null);
+
+  const debouncedSearchText = useDebounce(searchText, 500);
 
   useEffect(() => {
     const loadApiDocs = async () => {
@@ -295,6 +320,37 @@ const APIPanelContent: React.FC = () => {
 
     loadApiDocs();
   }, []);
+
+  const { query, isReady } = useOramaSearch(apiDocs, API_SEARCH_SCHEMA);
+
+  useEffect(() => {
+    const trimmed = debouncedSearchText.trim();
+    if (!trimmed) {
+      setSearchResults(null);
+      return;
+    }
+    if (!isReady) return;
+
+    let cancelled = false;
+    query(trimmed)
+      .then((results) => {
+        if (!cancelled) {
+          setSearchResults(results.map((r) => r.document));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSearchResults(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedSearchText, isReady, query]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchText, activeToggle]);
 
   const {
     bundleId = '',
@@ -315,14 +371,16 @@ const APIPanelContent: React.FC = () => {
     displayBundleName.toLowerCase() === 'home' ||
     displayBundleName.toLowerCase() === 'landing';
 
+  const baseResources = searchResults ?? apiDocs;
+
   const filteredResources = useMemo(() => {
     if (activeToggle === 'bundle' && !isHomePage) {
-      return apiDocs.filter((resource) =>
+      return baseResources.filter((resource) =>
         resource.services.includes(displayBundleName)
       );
     }
-    return apiDocs;
-  }, [activeToggle, isHomePage, displayBundleName, apiDocs]);
+    return baseResources;
+  }, [activeToggle, isHomePage, displayBundleName, baseResources]);
 
   const paginatedResources = useMemo(() => {
     const startIndex = (page - 1) * perPage;
@@ -355,6 +413,16 @@ const APIPanelContent: React.FC = () => {
     }
   };
 
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    setNewActionTitle(value);
+  };
+
+  const handleSearchClear = () => {
+    setSearchText('');
+    setNewActionTitle('');
+  };
+
   return (
     <Stack
       hasGutter
@@ -374,6 +442,16 @@ const APIPanelContent: React.FC = () => {
             {intl.formatMessage(messages.apiDocumentationCatalogLinkText)}
           </Button>
         </Content>
+      </StackItem>
+
+      <StackItem>
+        <SearchInput
+          placeholder={intl.formatMessage(messages.apiSearchPlaceholder)}
+          value={searchText}
+          onChange={(_event, value) => handleSearchChange(value)}
+          onClear={handleSearchClear}
+          data-ouia-component-id="help-panel-api-search-input"
+        />
       </StackItem>
 
       <StackItem>
@@ -468,10 +546,10 @@ const APIPanelContent: React.FC = () => {
 
 const APIPanel: React.FC<{
   setNewActionTitle: (title: string) => void;
-}> = () => {
+}> = ({ setNewActionTitle }) => {
   return (
     <Suspense fallback={<Spinner size="lg" />}>
-      <APIPanelContent />
+      <APIPanelContent setNewActionTitle={setNewActionTitle} />
     </Suspense>
   );
 };


### PR DESCRIPTION
### Description

Adds fuzzy search to the API documentation panel in the HelpPanel drawer. Previously, users could only toggle between "All" and bundle-scoped views with no way to search by name. This integrates Chrome's `useOramaSearch` hook (exposed via Module Federation) to enable fuzzy matching across API doc names and services — handling typos, partial matches, and multi-field search.

The search input follows the existing KBPanel pattern: debounced input (500ms), layered on top of the existing All/Bundle toggle filter, with pagination reset on filter changes.

[RHCLOUD-47884](https://issues.redhat.com/browse/RHCLOUD-47884)

---

### Anything reviewers should know?

- `useOramaSearch` is imported as a static Module Federation import (`chrome/search/useOramaSearch`). TypeScript declarations are in `globals.d.ts`; Jest resolution is handled via `moduleNameMapper` pointing to `src/__mocks__/chrome/`.
- The debounce hook is defined locally in `APIPanel.tsx` (same pattern as `SearchPanel.tsx`) rather than extracted to a shared utility — intentional to avoid coupling between panels.
- The `setNewActionTitle` prop was already defined on `APIPanel` but never wired through to `APIPanelContent`. This PR connects it so the search text propagates to the parent (consistent with KBPanel behavior).

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code (Opus 4.6)


[RHCLOUD-47884]: https://redhat.atlassian.net/browse/RHCLOUD-47884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ