### PR TITLE
chore(ci): update with nop image guard logic

### DIFF
--- a/.tekton/learning-resources-pull-request.yaml
+++ b/.tekton/learning-resources-pull-request.yaml
@@ -90,9 +90,9 @@ spec:
     resolver: git
     params:
     - name: url
-      value: https://github.com/catastrophe-brandon/konflux-pipelines
+      value: https://github.com/RedHatInsights/konflux-pipelines
     - name: revision
-      value: docs/e2e-sidecar-best-practices
+      value: main
     - name: pathInRepo
       value: pipelines/platform-ui/docker-build-run-all-tests.yaml
   taskRunTemplate:

--- a/.tekton/learning-resources-pull-request.yaml
+++ b/.tekton/learning-resources-pull-request.yaml
@@ -58,6 +58,13 @@ spec:
 
       set -e
 
+      # Guard against Tekton nop image replacement
+      # See: https://github.com/tektoncd/pipeline/issues/1347
+      if ! command -v caddy >/dev/null 2>&1; then
+        echo "Caddy not found - running in nop image, exiting gracefully"
+        exit 0
+      fi
+
       echo "Starting application with container's built-in Caddy configuration..."
       exec caddy run --config /etc/caddy/Caddyfile
   - name: e2e-playwright-image
@@ -83,9 +90,9 @@ spec:
     resolver: git
     params:
     - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
+      value: https://github.com/catastrophe-brandon/konflux-pipelines
     - name: revision
-      value: main
+      value: docs/e2e-sidecar-best-practices
     - name: pathInRepo
       value: pipelines/platform-ui/docker-build-run-all-tests.yaml
   taskRunTemplate:


### PR DESCRIPTION
## Summary
- Point pipeline to `catastrophe-brandon/konflux-pipelines` branch `docs/e2e-sidecar-best-practices`
- Add nop image guard to `run-app-script` to handle Tekton sidecar replacement gracefully

## Context
This updates the pipeline to use the best practices documented in the e2e-sidecar-best-practices branch, which includes improved sidecar handling and graceful shutdown behavior.

## Test plan
- [ ] Verify PR pipeline runs successfully with new branch reference
- [ ] Confirm nop image guard prevents errors during sidecar shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)