### PR TITLE
Remove border in Help Panel active tab

### DIFF
--- a/src/components/HelpPanel/HelpPanelCustomTabs.tsx
+++ b/src/components/HelpPanel/HelpPanelCustomTabs.tsx
@@ -178,7 +178,6 @@ const HelpPanelCustomTabs = React.forwardRef<HelpPanelCustomTabsRef>(
         <div className="lr-c-help-panel-tabs-wrapper">
           <Tabs
             className="lr-c-help-panel-custom-tabs"
-            isBox
             activeKey={activeTabId}
             onSelect={(_e, eventKey) => {
               if (typeof eventKey === 'string') {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

[RHCLOUD-49084](https://redhat.atlassian.net/browse/RHCLOUD-49084)
- Removes the border around Help Panel's active tab

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:

<img width="498" height="195" alt="image" src="https://github.com/user-attachments/assets/0ab988d6-0b83-42d6-acd8-405124f854e5" />
<img width="498" height="195" alt="image" src="https://github.com/user-attachments/assets/36fcb8f1-bb87-491d-bbf6-dceec3192a89" />

#### After:
<img width="498" height="195" alt="image" src="https://github.com/user-attachments/assets/dfca3670-c91d-4148-9408-882acce82111" />
<img width="498" height="195" alt="image" src="https://github.com/user-attachments/assets/427faa4e-8b97-4017-a908-4a1977953e73" />



---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [x ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-49084]: https://redhat.atlassian.net/browse/RHCLOUD-49084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ