### PR TITLE
feat(git-service): add PR button to create and update quickstarts 

### DIFF
--- a/cypress/component/CreatorYAMLView.cy.tsx
+++ b/cypress/component/CreatorYAMLView.cy.tsx
@@ -1,5 +1,26 @@
 import React from 'react';
+import { FlagProvider, IConfig } from '@unleash/proxy-client-react';
 import CreatorYAMLView from '../../src/components/creator/CreatorYAMLView';
+
+const unleashConfig: IConfig = {
+  appName: 'test-app',
+  url: 'https://unleash.example.com/api/',
+  clientKey: 'test',
+  refreshInterval: 0,
+  disableRefresh: true,
+  bootstrap: [
+    {
+      name: 'platform.learning-resources.quickstarts.git-service',
+      enabled: false,
+      impressionData: false,
+      variant: { name: 'disabled', enabled: false },
+    },
+  ],
+};
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <FlagProvider config={unleashConfig}>{children}</FlagProvider>
+);
 
 const setMonacoValue = (value: string) => {
   // Retry until Monaco is ready and models are available
@@ -35,7 +56,7 @@ const getMonacoValue = (): Cypress.Chainable<string> => {
 describe('CreatorYAMLView', () => {
   beforeEach(() => {
     // Mount the component before each test
-    cy.mount(<CreatorYAMLView />);
+    cy.mount(<Wrapper><CreatorYAMLView /></Wrapper>);
 
     // This single wait ensures the editor is ready for all tests
     cy.get('.lr-c-creator-yaml-view__editor', { timeout: 10000 }).should('be.visible');
@@ -97,11 +118,13 @@ describe('CreatorYAMLView', () => {
       const onChangeTags = cy.stub().as('onChangeTags');
 
       cy.mount(
-        <CreatorYAMLView
-          onChangeQuickStartSpec={onChangeQuickStartSpec}
-          onChangeBundles={onChangeBundles}
-          onChangeTags={onChangeTags}
-        />
+        <Wrapper>
+          <CreatorYAMLView
+            onChangeQuickStartSpec={onChangeQuickStartSpec}
+            onChangeBundles={onChangeBundles}
+            onChangeTags={onChangeTags}
+          />
+        </Wrapper>
       );
 
       // Wait for editor to initialize
@@ -132,7 +155,9 @@ spec:
       const onChangeQuickStartSpec = cy.stub().as('onChangeQuickStartSpec');
 
       cy.mount(
-        <CreatorYAMLView onChangeQuickStartSpec={onChangeQuickStartSpec} />
+        <Wrapper>
+          <CreatorYAMLView onChangeQuickStartSpec={onChangeQuickStartSpec} />
+        </Wrapper>
       );
 
       cy.get('.monaco-editor textarea', { timeout: 10000 }).should('exist');
@@ -160,7 +185,7 @@ spec:
     });
 
     it('should show error alert for invalid YAML', () => {
-      cy.mount(<CreatorYAMLView />);
+      cy.mount(<Wrapper><CreatorYAMLView /></Wrapper>);
 
       // Wait for editor to be ready
       cy.get('.monaco-editor textarea', { timeout: 10000 }).should('exist');
@@ -185,7 +210,9 @@ spec:
       const onChangeQuickStartSpec = cy.stub().as('onChangeQuickStartSpec');
 
       cy.mount(
-        <CreatorYAMLView onChangeQuickStartSpec={onChangeQuickStartSpec} />
+        <Wrapper>
+          <CreatorYAMLView onChangeQuickStartSpec={onChangeQuickStartSpec} />
+        </Wrapper>
       );
 
       // Wait for editor to initialize
@@ -221,7 +248,7 @@ spec:
     });
 
     it('should recover from error when valid YAML is entered', () => {
-      cy.mount(<CreatorYAMLView />);
+      cy.mount(<Wrapper><CreatorYAMLView /></Wrapper>);
 
       // Wait for editor to be ready
       cy.get('.monaco-editor textarea', { timeout: 10000 }).should('exist');
@@ -253,7 +280,7 @@ spec:
     });
 
     it('should update editor content via Monaco API', () => {
-      cy.mount(<CreatorYAMLView />);
+      cy.mount(<Wrapper><CreatorYAMLView /></Wrapper>);
 
       // Wait for editor to be ready
       cy.get('.monaco-editor textarea', { timeout: 10000 }).should('exist');

--- a/src/Creator.tsx
+++ b/src/Creator.tsx
@@ -47,7 +47,9 @@ const CreatorInternal = ({
   filterLoader: UnwrappedLoader<typeof fetchFilters>;
 }) => {
   const { data: filterData } = filterLoader();
-  const showGitService = useFlag('platform.learning-resources.quickstarts.git-service');
+  const showGitService = useFlag(
+    'platform.learning-resources.quickstarts.git-service'
+  );
   const [rawKind, setRawKind] = useState<ItemKind | null>(null);
   const filterMap = useFilterMap({ data: filterData });
 
@@ -257,7 +259,9 @@ const CreatorInternal = ({
                 updateSpec(() => spec);
               }}
               onChangeMetadataTags={updateMetadataTags}
-              onChangeMetadataName={showGitService ? updateMetadataName : undefined}
+              onChangeMetadataName={
+                showGitService ? updateMetadataName : undefined
+              }
               filterData={filterData}
               onChangeBundles={setBundles}
               onChangeCurrentStage={setCurrentStage}

--- a/src/Creator.tsx
+++ b/src/Creator.tsx
@@ -22,6 +22,7 @@ import useSuspenseLoader, {
 import fetchFilters from './utils/fetchFilters';
 import { ExtendedQuickstart } from './utils/fetchQuickstarts';
 import useFilterMap from './hooks/useFilterMap';
+import { useFlag } from '@unleash/proxy-client-react';
 
 function makeDemoQuickStart(
   kind: ItemKind | null,
@@ -46,6 +47,7 @@ const CreatorInternal = ({
   filterLoader: UnwrappedLoader<typeof fetchFilters>;
 }) => {
   const { data: filterData } = filterLoader();
+  const showGitService = useFlag('platform.learning-resources.quickstarts.git-service');
   const [rawKind, setRawKind] = useState<ItemKind | null>(null);
   const filterMap = useFilterMap({ data: filterData });
 
@@ -156,10 +158,27 @@ const CreatorInternal = ({
     setRawKind(newKind);
   };
 
-  const quickStart = useMemo(
-    () => makeDemoQuickStart(rawKind, rawQuickStart),
-    [rawKind, rawQuickStart]
-  );
+  const quickStart = useMemo(() => {
+    const demo = makeDemoQuickStart(rawKind, rawQuickStart);
+    if (!showGitService) return demo;
+
+    const allTags = bundles.toSorted().map((bundle) => ({
+      kind: 'bundle',
+      value: bundle,
+    }));
+    Object.entries(tags).forEach(([kind, values]) => {
+      values.forEach((value) => {
+        allTags.push({ kind, value });
+      });
+    });
+    return {
+      ...demo,
+      metadata: {
+        ...demo.metadata,
+        tags: allTags,
+      },
+    };
+  }, [rawKind, rawQuickStart, bundles, tags, showGitService]);
 
   const files = useMemo(() => {
     const effectiveName = quickStart.spec.displayName
@@ -238,7 +257,7 @@ const CreatorInternal = ({
                 updateSpec(() => spec);
               }}
               onChangeMetadataTags={updateMetadataTags}
-              onChangeMetadataName={updateMetadataName}
+              onChangeMetadataName={showGitService ? updateMetadataName : undefined}
               filterData={filterData}
               onChangeBundles={setBundles}
               onChangeCurrentStage={setCurrentStage}

--- a/src/Creator.tsx
+++ b/src/Creator.tsx
@@ -23,10 +23,6 @@ import fetchFilters from './utils/fetchFilters';
 import { ExtendedQuickstart } from './utils/fetchQuickstarts';
 import useFilterMap from './hooks/useFilterMap';
 
-const BASE_METADATA = {
-  name: 'test-quickstart',
-};
-
 function makeDemoQuickStart(
   kind: ItemKind | null,
   baseQuickStart: ExtendedQuickstart
@@ -37,7 +33,6 @@ function makeDemoQuickStart(
     ...baseQuickStart,
     metadata: {
       ...baseQuickStart.metadata,
-      name: 'test-quickstart',
       ...(kindMeta?.extraMetadata ?? {}),
     },
   };
@@ -85,6 +80,16 @@ const CreatorInternal = ({
       spec: {
         ...old.spec,
         ...updater(old.spec),
+      },
+    }));
+  };
+
+  const updateMetadataName = (name: string) => {
+    setRawQuickStart((old) => ({
+      ...old,
+      metadata: {
+        ...old.metadata,
+        name,
       },
     }));
   };
@@ -139,8 +144,8 @@ const CreatorInternal = ({
           });
         });
         updates.metadata = {
+          name: old.metadata.name,
           tags: allTags,
-          ...BASE_METADATA,
           ...meta.extraMetadata,
         };
 
@@ -233,6 +238,7 @@ const CreatorInternal = ({
                 updateSpec(() => spec);
               }}
               onChangeMetadataTags={updateMetadataTags}
+              onChangeMetadataName={updateMetadataName}
               filterData={filterData}
               onChangeBundles={setBundles}
               onChangeCurrentStage={setCurrentStage}

--- a/src/components/creator/CreatePRModal.tsx
+++ b/src/components/creator/CreatePRModal.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Alert,
+  Button,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Spinner,
+} from '@patternfly/react-core';
+import CodeBranchIcon from '@patternfly/react-icons/dist/dynamic/icons/code-branch-icon';
+import { PRResponse } from '../../utils/createQuickstartPR';
+
+type CreatePRModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  quickstartName: string;
+  prLoading: boolean;
+  prResult: PRResponse | null;
+  prError: string | null;
+};
+
+const CreatePRModal: React.FC<CreatePRModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  quickstartName,
+  prLoading,
+  prResult,
+  prError,
+}) => {
+  const showConfirm = !prLoading && !prResult && !prError;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={prLoading ? undefined : onClose}
+      aria-label="Create Pull Request"
+      variant="small"
+    >
+      <ModalHeader
+        title={
+          prResult
+            ? 'Pull Request Created'
+            : prError
+            ? 'Pull Request Failed'
+            : 'Create Pull Request'
+        }
+      />
+      <ModalBody>
+        {showConfirm && (
+          <Content component="p">
+            This will submit a pull request for{' '}
+            <strong>{quickstartName}</strong> to the quickstarts repository. The
+            PR will be checked against existing quickstarts to determine if this
+            is a new submission or an update.
+          </Content>
+        )}
+        {prLoading && (
+          <div style={{ textAlign: 'center', padding: '24px 0' }}>
+            <Spinner size="lg" />
+            <Content component="p" className="pf-v6-u-mt-md">
+              Submitting pull request...
+            </Content>
+          </div>
+        )}
+        {prResult && (
+          <Alert variant="success" title="PR created successfully" isInline>
+            <a href={prResult.prUrl} target="_blank" rel="noopener noreferrer">
+              {prResult.prUrl}
+            </a>
+          </Alert>
+        )}
+        {prError && (
+          <Alert variant="danger" title="Failed to create PR" isInline>
+            {prError}
+          </Alert>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        {showConfirm && (
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            icon={<CodeBranchIcon />}
+          >
+            Confirm
+          </Button>
+        )}
+        {prError && (
+          <Button variant="primary" onClick={onConfirm}>
+            Retry
+          </Button>
+        )}
+        <Button variant="link" onClick={onClose} isDisabled={prLoading}>
+          {prResult ? 'Close' : 'Cancel'}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default CreatePRModal;

--- a/src/components/creator/CreatorWizard.test.tsx
+++ b/src/components/creator/CreatorWizard.test.tsx
@@ -3,6 +3,10 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import CreatorWizard, { CreatorWizardProps } from './CreatorWizard';
 import { ExtendedQuickstart } from '../../utils/fetchQuickstarts';
 
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: () => false,
+}));
+
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   __esModule: true,
   useChrome: () => ({

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Banner,
   Button,
   ClipboardCopy,
@@ -6,6 +7,7 @@ import {
   Content,
   Flex,
   FlexItem,
+  Spinner,
   Stack,
   StackItem,
   Tab,
@@ -14,6 +16,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/dynamic/icons/check-circle-icon';
+import CodeBranchIcon from '@patternfly/react-icons/dist/dynamic/icons/code-branch-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/dynamic/icons/download-icon';
 import React, {
   Fragment,
@@ -56,6 +59,7 @@ import { CreatorFiles } from './types';
 import { FilterData } from '../../utils/FiltersCategoryInterface';
 import TagsSelector from './TagsSelector';
 import CreatorYAMLView from './CreatorYAMLView';
+import { useCreatePR } from './useCreatePR';
 
 export type CreatorWizardProps = {
   onChangeKind: (newKind: ItemKind | null) => void;
@@ -216,6 +220,25 @@ const PropUpdater = ({
 const FileDownload = () => {
   const { files } = useContext(CreatorWizardContext);
 
+  const quickstartName = useMemo(() => {
+    const yamlFile = files.find(
+      (f) => f.name !== 'metadata.yaml' && f.name.endsWith('.yaml')
+    );
+    if (!yamlFile) return null;
+    const name = yamlFile.name.replace(/\.yaml$/, '');
+    return name || null;
+  }, [files]);
+
+  const {
+    prLoading,
+    prResult,
+    prError,
+    canCreatePR,
+    handleCreatePR,
+    setPrResult,
+    setPrError,
+  } = useCreatePR(quickstartName);
+
   function doDownload(file: { content: string; name: string }) {
     const dotIndex = file.name.lastIndexOf('.');
     const baseName =
@@ -240,29 +263,84 @@ const FileDownload = () => {
       <Stack hasGutter className="pf-v6-u-m-lg">
         <StackItem>
           <Content component="p">
-            Download these files and use them to create the learning resource PR
-            in the{' '}
-            <a
-              href="https://github.com/RedHatInsights/quickstarts/tree/main/docs/quickstarts"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {' '}
-              correct repo
-            </a>
-            .
+            Download these files or submit them directly as a pull request.
           </Content>
         </StackItem>
 
         <StackItem>
-          <Button
-            variant="primary"
-            icon={<DownloadIcon />}
-            onClick={() => files.forEach((file) => doDownload(file))}
-          >
-            Download all ({files.length}) files
-          </Button>
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <FlexItem>
+              <Button
+                variant="primary"
+                icon={<DownloadIcon />}
+                onClick={() => files.forEach((file) => doDownload(file))}
+              >
+                Download all ({files.length}) files
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="primary"
+                icon={
+                  prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />
+                }
+                onClick={handleCreatePR}
+                isDisabled={!canCreatePR || prLoading}
+                isLoading={prLoading}
+              >
+                {prLoading ? 'Creating PR...' : 'Create PR'}
+              </Button>
+            </FlexItem>
+          </Flex>
         </StackItem>
+
+        {prResult && (
+          <StackItem>
+            <Alert
+              variant="success"
+              title="Pull Request Created"
+              isInline
+              actionClose={
+                <Button
+                  variant="plain"
+                  onClick={() => setPrResult(null)}
+                >
+                  ✕
+                </Button>
+              }
+            >
+              <a
+                href={prResult.prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {prResult.prUrl}
+              </a>
+            </Alert>
+          </StackItem>
+        )}
+        {prError && (
+          <StackItem>
+            <Alert
+              variant="danger"
+              title="Failed to Create PR"
+              isInline
+              actionClose={
+                <Button
+                  variant="plain"
+                  onClick={() => setPrError(null)}
+                >
+                  ✕
+                </Button>
+              }
+            >
+              {prError}{' '}
+              <Button variant="link" isInline onClick={handleCreatePR}>
+                Retry
+              </Button>
+            </Alert>
+          </StackItem>
+        )}
 
         {files.map((file) => (
           <StackItem key={file.name}>

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -1,6 +1,4 @@
 import {
-  Alert,
-  AlertActionCloseButton,
   Banner,
   Button,
   ClipboardCopy,
@@ -63,6 +61,7 @@ import CreatorYAMLView from './CreatorYAMLView';
 import { useCreatePR } from './useCreatePR';
 import SourceSelector from './SourceSelector';
 import { useFlag } from '@unleash/proxy-client-react';
+import CreatePRModal from './CreatePRModal';
 
 export type CreatorWizardProps = {
   onChangeKind: (newKind: ItemKind | null) => void;
@@ -255,6 +254,18 @@ const FileDownload = () => {
     setPrError,
   } = useCreatePR(quickstartName);
 
+  const [prModalOpen, setPrModalOpen] = useState(false);
+
+  const handleOpenPRModal = () => {
+    setPrResult(null);
+    setPrError(null);
+    setPrModalOpen(true);
+  };
+
+  const handleClosePRModal = () => {
+    setPrModalOpen(false);
+  };
+
   function doDownload(file: { content: string; name: string }) {
     const dotIndex = file.name.lastIndexOf('.');
     const baseName =
@@ -314,12 +325,11 @@ const FileDownload = () => {
               <FlexItem>
                 <Button
                   variant="primary"
-                  icon={prLoading ? undefined : <CodeBranchIcon />}
-                  onClick={handleCreatePR}
-                  isDisabled={!canCreatePR || prLoading}
-                  isLoading={prLoading}
+                  icon={<CodeBranchIcon />}
+                  onClick={handleOpenPRModal}
+                  isDisabled={!canCreatePR}
                 >
-                  {prLoading ? 'Submitting PR...' : 'Create PR'}
+                  Create PR
                 </Button>
               </FlexItem>
             </Flex>
@@ -334,42 +344,16 @@ const FileDownload = () => {
           )}
         </StackItem>
 
-        {showGitService && prResult && (
-          <StackItem>
-            <Alert
-              variant="success"
-              title="Pull Request Created"
-              isInline
-              actionClose={
-                <AlertActionCloseButton onClose={() => setPrResult(null)} />
-              }
-            >
-              <a
-                href={prResult.prUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {prResult.prUrl}
-              </a>
-            </Alert>
-          </StackItem>
-        )}
-        {showGitService && prError && (
-          <StackItem>
-            <Alert
-              variant="danger"
-              title="Failed to Create PR"
-              isInline
-              actionClose={
-                <AlertActionCloseButton onClose={() => setPrError(null)} />
-              }
-            >
-              {prError}{' '}
-              <Button variant="link" isInline onClick={handleCreatePR}>
-                Retry
-              </Button>
-            </Alert>
-          </StackItem>
+        {showGitService && quickstartName && (
+          <CreatePRModal
+            isOpen={prModalOpen}
+            onClose={handleClosePRModal}
+            onConfirm={handleCreatePR}
+            quickstartName={quickstartName}
+            prLoading={prLoading}
+            prResult={prResult}
+            prError={prError}
+          />
         )}
 
         {files.map((file) => (

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  AlertActionCloseButton,
   Banner,
   Button,
   ClipboardCopy,
@@ -318,7 +319,7 @@ const FileDownload = () => {
                   isDisabled={!canCreatePR || prLoading}
                   isLoading={prLoading}
                 >
-                  {prLoading ? 'Creating PR...' : 'Create PR'}
+                  {prLoading ? 'Submitting PR...' : 'Create PR'}
                 </Button>
               </FlexItem>
             </Flex>
@@ -340,9 +341,7 @@ const FileDownload = () => {
               title="Pull Request Created"
               isInline
               actionClose={
-                <Button variant="plain" onClick={() => setPrResult(null)}>
-                  ✕
-                </Button>
+                <AlertActionCloseButton onClose={() => setPrResult(null)} />
               }
             >
               <a
@@ -362,9 +361,7 @@ const FileDownload = () => {
               title="Failed to Create PR"
               isInline
               actionClose={
-                <Button variant="plain" onClick={() => setPrError(null)}>
-                  ✕
-                </Button>
+                <AlertActionCloseButton onClose={() => setPrError(null)} />
               }
             >
               {prError}{' '}
@@ -452,7 +449,7 @@ const CreatorWizard = ({
   const [viewMode, setViewMode] = useState<ViewMode>('wizard');
   const schema = useMemo(
     () => makeSchema(chrome, filterData, showGitService),
-    [showGitService]
+    [chrome, filterData, showGitService]
   );
   const availableBundles = useMemo(() => chrome.getAvailableBundles(), []);
 

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -45,6 +45,7 @@ import {
   NAME_DESCRIPTION,
   NAME_DURATION,
   NAME_KIND,
+  NAME_METADATA_NAME,
   NAME_PANEL_INTRODUCTION,
   NAME_PREREQUISITES,
   NAME_TAGS,
@@ -60,6 +61,7 @@ import { FilterData } from '../../utils/FiltersCategoryInterface';
 import TagsSelector from './TagsSelector';
 import CreatorYAMLView from './CreatorYAMLView';
 import { useCreatePR } from './useCreatePR';
+import SourceSelector from './SourceSelector';
 
 export type CreatorWizardProps = {
   onChangeKind: (newKind: ItemKind | null) => void;
@@ -71,6 +73,7 @@ export type CreatorWizardProps = {
   filterData: FilterData;
   onChangeTags: (tags: { [kind: string]: string[] }) => void;
   onChangeMetadataTags: (tags: Array<{ kind: string; value: string }>) => void;
+  onChangeMetadataName?: (name: string) => void;
   quickStart?: ExtendedQuickstart;
   currentBundles?: string[];
   currentTags?: { [kind: string]: string[] };
@@ -88,6 +91,7 @@ type UpdaterProps = {
   onChangeBundles: (bundles: string[]) => void;
   onChangeQuickStartSpec: (newValue: QuickStartSpec) => void;
   onChangeTags: CreatorWizardProps['onChangeTags'];
+  onChangeMetadataName?: (name: string) => void;
 };
 
 const DEFAULT_TASK_TITLES: string[] = [''];
@@ -116,9 +120,11 @@ const PropUpdater = ({
   onChangeTags,
   onChangeBundles,
   onChangeQuickStartSpec,
+  onChangeMetadataName,
 }: UpdaterProps) => {
   const bundles = values[NAME_BUNDLES];
   const tags = values[NAME_TAGS];
+  const metadataName: string | undefined = values[NAME_METADATA_NAME];
 
   useEffect(() => {
     onChangeBundles(bundles ?? []);
@@ -127,6 +133,12 @@ const PropUpdater = ({
   useEffect(() => {
     onChangeTags(tags ?? {});
   }, [tags]);
+
+  useEffect(() => {
+    if (metadataName && onChangeMetadataName) {
+      onChangeMetadataName(metadataName);
+    }
+  }, [metadataName]);
 
   const rawKind: string | undefined = values[NAME_KIND];
   const title: string | undefined = values[NAME_TITLE];
@@ -403,6 +415,7 @@ const CreatorWizard = ({
   resetCreator,
   onChangeTags,
   onChangeMetadataTags,
+  onChangeMetadataName,
   files,
   filterData,
   quickStart,
@@ -468,6 +481,7 @@ const CreatorWizard = ({
     'lr-task-title-preview': TaskTitlePreview,
     'lr-string-array': StringArrayInput,
     'lr-tag-filter-selector': TagsSelector,
+    'lr-source-selector': SourceSelector,
   };
 
   return (
@@ -522,6 +536,7 @@ const CreatorWizard = ({
                     onChangeTags={onChangeTags}
                     onChangeBundles={onChangeBundles}
                     onChangeQuickStartSpec={onChangeQuickStartSpec}
+                    onChangeMetadataName={onChangeMetadataName}
                   />
                 )}
               </FormSpy>

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -230,7 +230,9 @@ const PropUpdater = ({
 };
 
 const FileDownload = () => {
-  const showGitService = useFlag('platform.learning-resources.quickstarts.git-service');
+  const showGitService = useFlag(
+    'platform.learning-resources.quickstarts.git-service'
+  );
   const { files } = useContext(CreatorWizardContext);
 
   const quickstartName = useMemo(() => {
@@ -281,8 +283,8 @@ const FileDownload = () => {
             </Content>
           ) : (
             <Content component="p">
-              Download these files and use them to create the learning resource PR
-              in the{' '}
+              Download these files and use them to create the learning resource
+              PR in the{' '}
               <a
                 href="https://github.com/RedHatInsights/quickstarts/tree/main/docs/quickstarts"
                 target="_blank"
@@ -311,9 +313,7 @@ const FileDownload = () => {
               <FlexItem>
                 <Button
                   variant="primary"
-                  icon={
-                    prLoading ? undefined : <CodeBranchIcon />
-                  }
+                  icon={prLoading ? undefined : <CodeBranchIcon />}
                   onClick={handleCreatePR}
                   isDisabled={!canCreatePR || prLoading}
                   isLoading={prLoading}
@@ -340,10 +340,7 @@ const FileDownload = () => {
               title="Pull Request Created"
               isInline
               actionClose={
-                <Button
-                  variant="plain"
-                  onClick={() => setPrResult(null)}
-                >
+                <Button variant="plain" onClick={() => setPrResult(null)}>
                   ✕
                 </Button>
               }
@@ -365,10 +362,7 @@ const FileDownload = () => {
               title="Failed to Create PR"
               isInline
               actionClose={
-                <Button
-                  variant="plain"
-                  onClick={() => setPrError(null)}
-                >
+                <Button variant="plain" onClick={() => setPrError(null)}>
                   ✕
                 </Button>
               }
@@ -452,9 +446,14 @@ const CreatorWizard = ({
   onChangeKindDirect,
 }: CreatorWizardProps) => {
   const chrome = useChrome();
-  const showGitService = useFlag('platform.learning-resources.quickstarts.git-service');
+  const showGitService = useFlag(
+    'platform.learning-resources.quickstarts.git-service'
+  );
   const [viewMode, setViewMode] = useState<ViewMode>('wizard');
-  const schema = useMemo(() => makeSchema(chrome, filterData, showGitService), [showGitService]);
+  const schema = useMemo(
+    () => makeSchema(chrome, filterData, showGitService),
+    [showGitService]
+  );
   const availableBundles = useMemo(() => chrome.getAvailableBundles(), []);
 
   // [viewMode] only, including props like quickStart, currentKind, etc would recompute on

--- a/src/components/creator/CreatorWizard.tsx
+++ b/src/components/creator/CreatorWizard.tsx
@@ -7,7 +7,6 @@ import {
   Content,
   Flex,
   FlexItem,
-  Spinner,
   Stack,
   StackItem,
   Tab,
@@ -62,6 +61,7 @@ import TagsSelector from './TagsSelector';
 import CreatorYAMLView from './CreatorYAMLView';
 import { useCreatePR } from './useCreatePR';
 import SourceSelector from './SourceSelector';
+import { useFlag } from '@unleash/proxy-client-react';
 
 export type CreatorWizardProps = {
   onChangeKind: (newKind: ItemKind | null) => void;
@@ -230,6 +230,7 @@ const PropUpdater = ({
 };
 
 const FileDownload = () => {
+  const showGitService = useFlag('platform.learning-resources.quickstarts.git-service');
   const { files } = useContext(CreatorWizardContext);
 
   const quickstartName = useMemo(() => {
@@ -274,39 +275,65 @@ const FileDownload = () => {
 
       <Stack hasGutter className="pf-v6-u-m-lg">
         <StackItem>
-          <Content component="p">
-            Download these files or submit them directly as a pull request.
-          </Content>
+          {showGitService ? (
+            <Content component="p">
+              Download these files or submit them directly as a pull request.
+            </Content>
+          ) : (
+            <Content component="p">
+              Download these files and use them to create the learning resource PR
+              in the{' '}
+              <a
+                href="https://github.com/RedHatInsights/quickstarts/tree/main/docs/quickstarts"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {' '}
+                correct repo
+              </a>
+              .
+            </Content>
+          )}
         </StackItem>
 
         <StackItem>
-          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              <Button
-                variant="primary"
-                icon={<DownloadIcon />}
-                onClick={() => files.forEach((file) => doDownload(file))}
-              >
-                Download all ({files.length}) files
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Button
-                variant="primary"
-                icon={
-                  prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />
-                }
-                onClick={handleCreatePR}
-                isDisabled={!canCreatePR || prLoading}
-                isLoading={prLoading}
-              >
-                {prLoading ? 'Creating PR...' : 'Create PR'}
-              </Button>
-            </FlexItem>
-          </Flex>
+          {showGitService ? (
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <Button
+                  variant="primary"
+                  icon={<DownloadIcon />}
+                  onClick={() => files.forEach((file) => doDownload(file))}
+                >
+                  Download all ({files.length}) files
+                </Button>
+              </FlexItem>
+              <FlexItem>
+                <Button
+                  variant="primary"
+                  icon={
+                    prLoading ? undefined : <CodeBranchIcon />
+                  }
+                  onClick={handleCreatePR}
+                  isDisabled={!canCreatePR || prLoading}
+                  isLoading={prLoading}
+                >
+                  {prLoading ? 'Creating PR...' : 'Create PR'}
+                </Button>
+              </FlexItem>
+            </Flex>
+          ) : (
+            <Button
+              variant="primary"
+              icon={<DownloadIcon />}
+              onClick={() => files.forEach((file) => doDownload(file))}
+            >
+              Download all ({files.length}) files
+            </Button>
+          )}
         </StackItem>
 
-        {prResult && (
+        {showGitService && prResult && (
           <StackItem>
             <Alert
               variant="success"
@@ -331,7 +358,7 @@ const FileDownload = () => {
             </Alert>
           </StackItem>
         )}
-        {prError && (
+        {showGitService && prError && (
           <StackItem>
             <Alert
               variant="danger"
@@ -425,8 +452,9 @@ const CreatorWizard = ({
   onChangeKindDirect,
 }: CreatorWizardProps) => {
   const chrome = useChrome();
+  const showGitService = useFlag('platform.learning-resources.quickstarts.git-service');
   const [viewMode, setViewMode] = useState<ViewMode>('wizard');
-  const schema = useMemo(() => makeSchema(chrome, filterData), []);
+  const schema = useMemo(() => makeSchema(chrome, filterData, showGitService), [showGitService]);
   const availableBundles = useMemo(() => chrome.getAvailableBundles(), []);
 
   // [viewMode] only, including props like quickStart, currentKind, etc would recompute on

--- a/src/components/creator/CreatorYAMLView.scss
+++ b/src/components/creator/CreatorYAMLView.scss
@@ -11,6 +11,7 @@
     height: 600px;
     max-height: 70vh;
     overflow: hidden;
+    margin-bottom: var(--pf-t--global--spacer--md);
   }
 }
 

--- a/src/components/creator/CreatorYAMLView.test.tsx
+++ b/src/components/creator/CreatorYAMLView.test.tsx
@@ -44,6 +44,11 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 
+let mockGitServiceFlag = false;
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: () => mockGitServiceFlag,
+}));
+
 // Mock Monaco Editor — render a simple textarea that mirrors onChange behavior
 jest.mock('@monaco-editor/react', () => {
   const MockEditor = ({
@@ -669,6 +674,12 @@ spec:
   });
 
   describe('Create PR button', () => {
+    beforeEach(() => {
+      mockGitServiceFlag = true;
+    });
+    afterEach(() => {
+      mockGitServiceFlag = false;
+    });
     it('renders Create PR button', () => {
       renderWithContext(<CreatorYAMLView />);
       expect(
@@ -769,6 +780,12 @@ spec:
   });
 
   describe('Mode detection label', () => {
+    beforeEach(() => {
+      mockGitServiceFlag = true;
+    });
+    afterEach(() => {
+      mockGitServiceFlag = false;
+    });
     it('shows "Creating" label for new quickstarts', async () => {
       mockedQuickstartExists.mockResolvedValue(false);
 
@@ -801,6 +818,12 @@ spec:
   });
 
   describe('Load from Repo', () => {
+    beforeEach(() => {
+      mockGitServiceFlag = true;
+    });
+    afterEach(() => {
+      mockGitServiceFlag = false;
+    });
     it('renders Load from Repo button', () => {
       renderWithContext(<CreatorYAMLView />);
       expect(

--- a/src/components/creator/CreatorYAMLView.test.tsx
+++ b/src/components/creator/CreatorYAMLView.test.tsx
@@ -737,6 +737,14 @@ spec:
 
       await waitFor(() => {
         expect(
+          screen.getByRole('button', { name: /confirm/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+      await waitFor(() => {
+        expect(
           screen.getByText('https://github.com/org/repo/pull/99')
         ).toBeInTheDocument();
       });
@@ -772,6 +780,14 @@ spec:
       fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
 
       await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /confirm/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+      await waitFor(() => {
         expect(mockedCreatePR).toHaveBeenCalled();
       });
 
@@ -804,6 +820,14 @@ spec:
       });
 
       fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /confirm/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
 
       await waitFor(() => {
         expect(screen.getByText(/Network error/)).toBeInTheDocument();

--- a/src/components/creator/CreatorYAMLView.test.tsx
+++ b/src/components/creator/CreatorYAMLView.test.tsx
@@ -860,7 +860,10 @@ spec:
 
       expect(mockedGetRepoQuickstartContent).toHaveBeenCalledWith('getting-started');
       const editor = screen.getByTestId('mock-monaco-editor');
-      expect((editor as HTMLTextAreaElement).value).toBe(yamlContent);
+      const editorValue = (editor as HTMLTextAreaElement).value;
+      expect(editorValue).toContain('kind: QuickStarts');
+      expect(editorValue).toContain('name: getting-started');
+      expect(editorValue).toContain('displayName: GS');
     });
   });
 });

--- a/src/components/creator/CreatorYAMLView.test.tsx
+++ b/src/components/creator/CreatorYAMLView.test.tsx
@@ -11,6 +11,12 @@ import { CreatorWizardContext } from './context';
 import { CreatorFiles } from './types';
 import { DEFAULT_QUICKSTART_YAML } from '../../data/quickstart-templates';
 import { ExtendedQuickstart } from '../../utils/fetchQuickstarts';
+import {
+  createQuickstartPR,
+  quickstartExists,
+  listRepoQuickstarts,
+  getRepoQuickstartContent,
+} from '../../utils/createQuickstartPR';
 
 // Mock downloadFile from frontend-components-utilities
 const mockDownloadFile = jest.fn();
@@ -20,6 +26,23 @@ jest.mock(
     downloadFile: (...args: unknown[]) => mockDownloadFile(...args),
   })
 );
+
+// Mock useChrome for SSO user email (co-authored-by)
+const mockGetUser = jest.fn().mockResolvedValue({
+  identity: {
+    user: {
+      email: 'testuser@redhat.com',
+      first_name: 'Test',
+      last_name: 'User',
+    },
+  },
+});
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  useChrome: () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}));
 
 // Mock Monaco Editor — render a simple textarea that mirrors onChange behavior
 jest.mock('@monaco-editor/react', () => {
@@ -39,6 +62,18 @@ jest.mock('@monaco-editor/react', () => {
   MockEditor.displayName = 'MockEditor';
   return { __esModule: true, default: MockEditor };
 });
+
+jest.mock('../../utils/createQuickstartPR', () => ({
+  createQuickstartPR: jest.fn(),
+  quickstartExists: jest.fn().mockResolvedValue(false),
+  listRepoQuickstarts: jest.fn().mockResolvedValue([]),
+  getRepoQuickstartContent: jest.fn().mockResolvedValue({ name: '', files: [] }),
+}));
+
+const mockedCreatePR = createQuickstartPR as jest.MockedFunction<typeof createQuickstartPR>;
+const mockedQuickstartExists = quickstartExists as jest.MockedFunction<typeof quickstartExists>;
+const mockedListRepoQuickstarts = listRepoQuickstarts as jest.MockedFunction<typeof listRepoQuickstarts>;
+const mockedGetRepoQuickstartContent = getRepoQuickstartContent as jest.MockedFunction<typeof getRepoQuickstartContent>;
 
 const MOCK_FILES: CreatorFiles = [
   { name: 'metadata.yaml', content: 'kind: QuickStarts\nname: test\n' },
@@ -630,6 +665,202 @@ spec:
       expect(onChangeSpec).toHaveBeenCalledWith(
         expect.objectContaining({ displayName: 'Debounce' })
       );
+    });
+  });
+
+  describe('Create PR button', () => {
+    it('renders Create PR button', () => {
+      renderWithContext(<CreatorYAMLView />);
+      expect(
+        screen.getByRole('button', { name: /create pr/i })
+      ).toBeInTheDocument();
+    });
+
+    it('disables Create PR button when YAML has parse error', () => {
+      renderWithContext(<CreatorYAMLView />);
+
+      const editor = screen.getByTestId('mock-monaco-editor');
+      fireEvent.change(editor, { target: { value: 'invalid: [unclosed' } });
+      act(() => { jest.advanceTimersByTime(200); });
+
+      const prBtn = screen.getByRole('button', { name: /create pr/i });
+      expect(prBtn).toBeDisabled();
+    });
+
+    it('shows success alert with PR link on success', async () => {
+      mockedCreatePR.mockResolvedValueOnce({
+        prUrl: 'https://github.com/org/repo/pull/99',
+        branchName: 'qs-create-my-qs-123',
+        commitSha: 'abc123',
+        status: 'created',
+      });
+
+      renderWithContext(<CreatorYAMLView />);
+
+      const editor = screen.getByTestId('mock-monaco-editor');
+      fireEvent.change(editor, {
+        target: { value: 'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n' },
+      });
+      act(() => { jest.advanceTimersByTime(200); });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create pr/i })).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('https://github.com/org/repo/pull/99')).toBeInTheDocument();
+      });
+    });
+
+    it('includes co-authored-by from SSO user in commit message', async () => {
+      mockedCreatePR.mockResolvedValueOnce({
+        prUrl: 'https://github.com/org/repo/pull/99',
+        branchName: 'qs-create-my-qs-123',
+        commitSha: 'abc123',
+        status: 'created',
+      });
+
+      renderWithContext(<CreatorYAMLView />);
+
+      const editor = screen.getByTestId('mock-monaco-editor');
+      fireEvent.change(editor, {
+        target: { value: 'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n' },
+      });
+      act(() => { jest.advanceTimersByTime(200); });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create pr/i })).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
+
+      await waitFor(() => {
+        expect(mockedCreatePR).toHaveBeenCalled();
+      });
+
+      const metadata = mockedCreatePR.mock.calls[0][1];
+      expect(metadata.commitMessage).toContain('Co-authored-by: Test User <testuser@redhat.com>');
+    });
+
+    it('shows error alert with retry on failure', async () => {
+      mockedCreatePR.mockRejectedValueOnce(new Error('Network error'));
+
+      renderWithContext(<CreatorYAMLView />);
+
+      const editor = screen.getByTestId('mock-monaco-editor');
+      fireEvent.change(editor, {
+        target: { value: 'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n' },
+      });
+      act(() => { jest.advanceTimersByTime(200); });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create pr/i })).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Network error/)).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Mode detection label', () => {
+    it('shows "Creating" label for new quickstarts', async () => {
+      mockedQuickstartExists.mockResolvedValue(false);
+
+      renderWithContext(<CreatorYAMLView />);
+      const editor = screen.getByTestId('mock-monaco-editor');
+      fireEvent.change(editor, {
+        target: { value: 'metadata:\n  name: brand-new-qs\nspec:\n  displayName: New\n' },
+      });
+      act(() => { jest.advanceTimersByTime(200); });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Creating: brand-new-qs/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows "Updating" label for existing quickstarts', async () => {
+      mockedQuickstartExists.mockResolvedValue(true);
+
+      renderWithContext(<CreatorYAMLView />);
+      const editor = screen.getByTestId('mock-monaco-editor');
+      fireEvent.change(editor, {
+        target: { value: 'metadata:\n  name: existing-qs\nspec:\n  displayName: Existing\n' },
+      });
+      act(() => { jest.advanceTimersByTime(200); });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Updating: existing-qs/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Load from Repo', () => {
+    it('renders Load from Repo button', () => {
+      renderWithContext(<CreatorYAMLView />);
+      expect(
+        screen.getByRole('button', { name: /load from repo/i })
+      ).toBeInTheDocument();
+    });
+
+    it('opens modal and shows quickstarts list', async () => {
+      mockedListRepoQuickstarts.mockResolvedValueOnce([
+        { name: 'getting-started', displayName: 'Getting Started' },
+        { name: 'cost-mgmt', displayName: 'Cost Management' },
+      ]);
+
+      renderWithContext(<CreatorYAMLView />);
+      fireEvent.click(screen.getByRole('button', { name: /load from repo/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Getting Started')).toBeInTheDocument();
+        expect(screen.getByText('Cost Management')).toBeInTheDocument();
+      });
+    });
+
+    it('loads quickstart content into editor on selection', async () => {
+      jest.useRealTimers();
+
+      mockedListRepoQuickstarts.mockResolvedValueOnce([
+        { name: 'getting-started', displayName: 'Getting Started' },
+      ]);
+      const yamlContent = 'metadata:\n  name: getting-started\nspec:\n  displayName: GS\n';
+      mockedGetRepoQuickstartContent.mockResolvedValueOnce({
+        name: 'getting-started',
+        files: [
+          { name: 'metadata.yaml', content: 'kind: QuickStarts\n' },
+          { name: 'getting-started.yml', content: yamlContent },
+        ],
+      });
+
+      renderWithContext(<CreatorYAMLView />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /load from repo/i }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Getting Started')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getting Started' }));
+
+      // Flush the async handleLoadFromRepo + React state updates
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(mockedGetRepoQuickstartContent).toHaveBeenCalledWith('getting-started');
+      const editor = screen.getByTestId('mock-monaco-editor');
+      expect((editor as HTMLTextAreaElement).value).toBe(yamlContent);
     });
   });
 });

--- a/src/components/creator/CreatorYAMLView.test.tsx
+++ b/src/components/creator/CreatorYAMLView.test.tsx
@@ -13,9 +13,9 @@ import { DEFAULT_QUICKSTART_YAML } from '../../data/quickstart-templates';
 import { ExtendedQuickstart } from '../../utils/fetchQuickstarts';
 import {
   createQuickstartPR,
-  quickstartExists,
-  listRepoQuickstarts,
   getRepoQuickstartContent,
+  listRepoQuickstarts,
+  quickstartExists,
 } from '../../utils/createQuickstartPR';
 
 // Mock downloadFile from frontend-components-utilities
@@ -72,13 +72,24 @@ jest.mock('../../utils/createQuickstartPR', () => ({
   createQuickstartPR: jest.fn(),
   quickstartExists: jest.fn().mockResolvedValue(false),
   listRepoQuickstarts: jest.fn().mockResolvedValue([]),
-  getRepoQuickstartContent: jest.fn().mockResolvedValue({ name: '', files: [] }),
+  getRepoQuickstartContent: jest
+    .fn()
+    .mockResolvedValue({ name: '', files: [] }),
 }));
 
-const mockedCreatePR = createQuickstartPR as jest.MockedFunction<typeof createQuickstartPR>;
-const mockedQuickstartExists = quickstartExists as jest.MockedFunction<typeof quickstartExists>;
-const mockedListRepoQuickstarts = listRepoQuickstarts as jest.MockedFunction<typeof listRepoQuickstarts>;
-const mockedGetRepoQuickstartContent = getRepoQuickstartContent as jest.MockedFunction<typeof getRepoQuickstartContent>;
+const mockedCreatePR = createQuickstartPR as jest.MockedFunction<
+  typeof createQuickstartPR
+>;
+const mockedQuickstartExists = quickstartExists as jest.MockedFunction<
+  typeof quickstartExists
+>;
+const mockedListRepoQuickstarts = listRepoQuickstarts as jest.MockedFunction<
+  typeof listRepoQuickstarts
+>;
+const mockedGetRepoQuickstartContent =
+  getRepoQuickstartContent as jest.MockedFunction<
+    typeof getRepoQuickstartContent
+  >;
 
 const MOCK_FILES: CreatorFiles = [
   { name: 'metadata.yaml', content: 'kind: QuickStarts\nname: test\n' },
@@ -692,7 +703,9 @@ spec:
 
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, { target: { value: 'invalid: [unclosed' } });
-      act(() => { jest.advanceTimersByTime(200); });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
 
       const prBtn = screen.getByRole('button', { name: /create pr/i });
       expect(prBtn).toBeDisabled();
@@ -710,18 +723,27 @@ spec:
 
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, {
-        target: { value: 'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n' },
+        target: {
+          value:
+            'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n',
+        },
       });
-      act(() => { jest.advanceTimersByTime(200); });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create pr/i })).not.toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: /create pr/i })
+        ).not.toBeDisabled();
       });
 
       fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
 
       await waitFor(() => {
-        expect(screen.getByText('https://github.com/org/repo/pull/99')).toBeInTheDocument();
+        expect(
+          screen.getByText('https://github.com/org/repo/pull/99')
+        ).toBeInTheDocument();
       });
     });
 
@@ -737,12 +759,19 @@ spec:
 
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, {
-        target: { value: 'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n' },
+        target: {
+          value:
+            'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n',
+        },
       });
-      act(() => { jest.advanceTimersByTime(200); });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create pr/i })).not.toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: /create pr/i })
+        ).not.toBeDisabled();
       });
 
       fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
@@ -752,7 +781,9 @@ spec:
       });
 
       const metadata = mockedCreatePR.mock.calls[0][1];
-      expect(metadata.commitMessage).toContain('Co-authored-by: Test User <testuser@redhat.com>');
+      expect(metadata.commitMessage).toContain(
+        'Co-authored-by: Test User <testuser@redhat.com>'
+      );
     });
 
     it('shows error alert with retry on failure', async () => {
@@ -762,12 +793,19 @@ spec:
 
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, {
-        target: { value: 'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n' },
+        target: {
+          value:
+            'metadata:\n  name: my-qs\nspec:\n  displayName: My QS\n  description: Desc\n',
+        },
       });
-      act(() => { jest.advanceTimersByTime(200); });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create pr/i })).not.toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: /create pr/i })
+        ).not.toBeDisabled();
       });
 
       fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
@@ -775,7 +813,9 @@ spec:
       await waitFor(() => {
         expect(screen.getByText(/Network error/)).toBeInTheDocument();
       });
-      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /retry/i })
+      ).toBeInTheDocument();
     });
   });
 
@@ -792,9 +832,13 @@ spec:
       renderWithContext(<CreatorYAMLView />);
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, {
-        target: { value: 'metadata:\n  name: brand-new-qs\nspec:\n  displayName: New\n' },
+        target: {
+          value: 'metadata:\n  name: brand-new-qs\nspec:\n  displayName: New\n',
+        },
       });
-      act(() => { jest.advanceTimersByTime(200); });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
 
       await waitFor(() => {
         expect(screen.getByText(/Creating: brand-new-qs/)).toBeInTheDocument();
@@ -807,9 +851,14 @@ spec:
       renderWithContext(<CreatorYAMLView />);
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, {
-        target: { value: 'metadata:\n  name: existing-qs\nspec:\n  displayName: Existing\n' },
+        target: {
+          value:
+            'metadata:\n  name: existing-qs\nspec:\n  displayName: Existing\n',
+        },
       });
-      act(() => { jest.advanceTimersByTime(200); });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
 
       await waitFor(() => {
         expect(screen.getByText(/Updating: existing-qs/)).toBeInTheDocument();
@@ -852,7 +901,8 @@ spec:
       mockedListRepoQuickstarts.mockResolvedValueOnce([
         { name: 'getting-started', displayName: 'Getting Started' },
       ]);
-      const yamlContent = 'metadata:\n  name: getting-started\nspec:\n  displayName: GS\n';
+      const yamlContent =
+        'metadata:\n  name: getting-started\nspec:\n  displayName: GS\n';
       mockedGetRepoQuickstartContent.mockResolvedValueOnce({
         name: 'getting-started',
         files: [
@@ -864,7 +914,9 @@ spec:
       renderWithContext(<CreatorYAMLView />);
 
       await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: /load from repo/i }));
+        fireEvent.click(
+          screen.getByRole('button', { name: /load from repo/i })
+        );
       });
 
       await waitFor(() => {
@@ -881,7 +933,9 @@ spec:
         await new Promise((r) => setTimeout(r, 0));
       });
 
-      expect(mockedGetRepoQuickstartContent).toHaveBeenCalledWith('getting-started');
+      expect(mockedGetRepoQuickstartContent).toHaveBeenCalledWith(
+        'getting-started'
+      );
       const editor = screen.getByTestId('mock-monaco-editor');
       const editorValue = (editor as HTMLTextAreaElement).value;
       expect(editorValue).toContain('kind: QuickStarts');

--- a/src/components/creator/CreatorYAMLView.test.tsx
+++ b/src/components/creator/CreatorYAMLView.test.tsx
@@ -15,7 +15,6 @@ import {
   createQuickstartPR,
   getRepoQuickstartContent,
   listRepoQuickstarts,
-  quickstartExists,
 } from '../../utils/createQuickstartPR';
 
 // Mock downloadFile from frontend-components-utilities
@@ -70,7 +69,6 @@ jest.mock('@monaco-editor/react', () => {
 
 jest.mock('../../utils/createQuickstartPR', () => ({
   createQuickstartPR: jest.fn(),
-  quickstartExists: jest.fn().mockResolvedValue(false),
   listRepoQuickstarts: jest.fn().mockResolvedValue([]),
   getRepoQuickstartContent: jest
     .fn()
@@ -79,9 +77,6 @@ jest.mock('../../utils/createQuickstartPR', () => ({
 
 const mockedCreatePR = createQuickstartPR as jest.MockedFunction<
   typeof createQuickstartPR
->;
-const mockedQuickstartExists = quickstartExists as jest.MockedFunction<
-  typeof quickstartExists
 >;
 const mockedListRepoQuickstarts = listRepoQuickstarts as jest.MockedFunction<
   typeof listRepoQuickstarts
@@ -826,9 +821,7 @@ spec:
     afterEach(() => {
       mockGitServiceFlag = false;
     });
-    it('shows "Creating" label for new quickstarts', async () => {
-      mockedQuickstartExists.mockResolvedValue(false);
-
+    it('shows "Editing" label when quickstart name is set', async () => {
       renderWithContext(<CreatorYAMLView />);
       const editor = screen.getByTestId('mock-monaco-editor');
       fireEvent.change(editor, {
@@ -841,27 +834,7 @@ spec:
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/Creating: brand-new-qs/)).toBeInTheDocument();
-      });
-    });
-
-    it('shows "Updating" label for existing quickstarts', async () => {
-      mockedQuickstartExists.mockResolvedValue(true);
-
-      renderWithContext(<CreatorYAMLView />);
-      const editor = screen.getByTestId('mock-monaco-editor');
-      fireEvent.change(editor, {
-        target: {
-          value:
-            'metadata:\n  name: existing-qs\nspec:\n  displayName: Existing\n',
-        },
-      });
-      act(() => {
-        jest.advanceTimersByTime(200);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText(/Updating: existing-qs/)).toBeInTheDocument();
+        expect(screen.getByText(/Editing: brand-new-qs/)).toBeInTheDocument();
       });
     });
   });

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -9,30 +9,52 @@ import React, {
 import {
   Alert,
   Button,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
   Divider,
   Flex,
   FlexItem,
   FormGroup,
+  Label,
   List,
   ListItem,
   MenuToggle,
   MenuToggleElement,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
   PageSection,
+  SearchInput,
   Select,
   SelectGroup,
   SelectList,
   SelectOption,
+  Spinner,
   Tooltip,
 } from '@patternfly/react-core';
 import {
+  CodeBranchIcon,
   DownloadIcon,
   FileImportIcon,
   UploadIcon,
 } from '@patternfly/react-icons';
+import {
+  createQuickstartPR,
+  getRepoQuickstartContent,
+  listRepoQuickstarts,
+  quickstartExists,
+  PRResponse,
+  RepoQuickstartEntry,
+} from '../../utils/createQuickstartPR';
 import Editor from '@monaco-editor/react';
 import YAML from 'yaml';
 import { QuickStartSpec } from '@patternfly/quickstarts';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { ExtendedQuickstart } from '../../utils/fetchQuickstarts';
 import { CreatorWizardContext } from './context';
 import { ALL_KIND_ENTRIES, ItemKind } from './meta';
@@ -418,6 +440,22 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
   bundles: bundleOptions,
 }) => {
   const { files } = useContext(CreatorWizardContext);
+  const chrome = useChrome();
+
+  // Hardcoded to true for local dev — revert to useFlag before opening PR:
+  const showCreatePR = useFlag('platform.learning-resources.quickstarts.create-pr');
+  // const showCreatePR = true;
+
+  const [prLoading, setPrLoading] = useState(false);
+  const [prResult, setPrResult] = useState<PRResponse | null>(null);
+  const [prError, setPrError] = useState<string | null>(null);
+  const [isUpdate, setIsUpdate] = useState(false);
+  const [parsedName, setParsedName] = useState<string | null>(null);
+  const [repoModalOpen, setRepoModalOpen] = useState(false);
+  const [repoQuickstarts, setRepoQuickstarts] = useState<RepoQuickstartEntry[]>([]);
+  const [repoLoading, setRepoLoading] = useState(false);
+  const [repoSearch, setRepoSearch] = useState('');
+  const [repoError, setRepoError] = useState<string | null>(null);
 
   // On mount, serialize current state to YAML if we have data from the wizard.
   // This enables switching wizard → YAML without losing data.
@@ -509,6 +547,17 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
 
       // Update state
       setParseError(null);
+
+      // Track parsed name for mode detection
+      const name = metadata.name || null;
+      if (name !== parsedName) {
+        setParsedName(name);
+        if (name && name !== 'untitled-quickstart') {
+          quickstartExists(name).then(setIsUpdate);
+        } else {
+          setIsUpdate(false);
+        }
+      }
 
       // Detect and propagate kind from spec.type
       const detectedKind = detectKind(spec);
@@ -645,6 +694,77 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
     });
   };
 
+  const handleCreatePR = async () => {
+    if (!parsedName || prLoading) return;
+    setPrLoading(true);
+    setPrResult(null);
+    setPrError(null);
+    try {
+      const timestamp = Date.now();
+      const prefix = isUpdate ? 'update' : 'create';
+      let commitMessage = `feat(quickstarts): ${prefix} ${parsedName}`;
+      const user = await chrome.auth.getUser();
+      const identity = user?.identity?.user;
+      if (identity?.email) {
+        const name = [identity.first_name, identity.last_name].filter(Boolean).join(' ') || identity.email;
+        commitMessage += `\n\nCo-authored-by: ${name} <${identity.email}>`;
+      }
+      const result = await createQuickstartPR(files, {
+        branchName: `qs-${prefix}-${parsedName}-${timestamp}`,
+        commitMessage,
+        prTitle: `feat(quickstarts): ${prefix} ${parsedName}`,
+        prBody: `${isUpdate ? 'Updating' : 'Adding new'} quickstart via the Quickstarts Creator tool.\n\nDirectory: docs/quickstarts/${parsedName}/`,
+        isUpdate,
+        directoryName: parsedName,
+        ...(isUpdate ? { existingPath: `docs/quickstarts/${parsedName}/` } : {}),
+      });
+      setPrResult(result);
+    } catch (err) {
+      setPrError(err instanceof Error ? err.message : 'Failed to create PR');
+    } finally {
+      setPrLoading(false);
+    }
+  };
+
+  const handleOpenRepoModal = async () => {
+    setRepoModalOpen(true);
+    setRepoLoading(true);
+    setRepoError(null);
+    setRepoSearch('');
+    try {
+      const entries = await listRepoQuickstarts();
+      setRepoQuickstarts(entries);
+    } catch (err) {
+      setRepoError(err instanceof Error ? err.message : 'Failed to load quickstarts');
+    } finally {
+      setRepoLoading(false);
+    }
+  };
+
+  const handleLoadFromRepo = async (name: string) => {
+    setRepoModalOpen(false);
+    try {
+      const content = await getRepoQuickstartContent(name);
+      const yamlFile = content.files.find(
+        (f) =>
+          (f.name.endsWith('.yml') || f.name.endsWith('.yaml')) &&
+          f.name !== 'metadata.yaml'
+      );
+      if (yamlFile) {
+        setYamlContent(yamlFile.content);
+        parseAndUpdateQuickstart(yamlFile.content);
+      }
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : 'Failed to load quickstart');
+    }
+  };
+
+  const filteredRepoQuickstarts = repoQuickstarts.filter(
+    (qs) =>
+      qs.name.toLowerCase().includes(repoSearch.toLowerCase()) ||
+      qs.displayName.toLowerCase().includes(repoSearch.toLowerCase())
+  );
+
   /**
    * Update the metadata.tags section inside the current YAML editor content
    * when bundles or tags are changed via the UI selectors.
@@ -696,6 +816,9 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
   const canDownload =
     isUserContent(yamlContent) && !parseError && files.length > 0;
 
+  const canCreatePR =
+    canDownload && !!parsedName && parsedName !== 'untitled-quickstart';
+
   return (
     <PageSection className="lr-c-creator-yaml-view">
       {parseError && (
@@ -724,9 +847,37 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           </List>
         </Alert>
       )}
+      {prResult && (
+        <Alert
+          variant="success"
+          title="Pull Request Created"
+          className="pf-v6-u-mb-md"
+          isInline
+          actionClose={<Button variant="plain" onClick={() => setPrResult(null)}>✕</Button>}
+        >
+          <a href={prResult.prUrl} target="_blank" rel="noopener noreferrer">
+            {prResult.prUrl}
+          </a>
+        </Alert>
+      )}
+      {prError && (
+        <Alert
+          variant="danger"
+          title="Failed to Create PR"
+          className="pf-v6-u-mb-md"
+          isInline
+          actionClose={<Button variant="plain" onClick={() => setPrError(null)}>✕</Button>}
+        >
+          {prError}{' '}
+          <Button variant="link" isInline onClick={handleCreatePR}>
+            Retry
+          </Button>
+        </Alert>
+      )}
       <Flex
         spaceItems={{ default: 'spaceItemsSm' }}
         className="lr-c-creator-yaml-view__toolbar"
+        alignItems={{ default: 'alignItemsCenter' }}
       >
         <FlexItem>
           <Button
@@ -772,6 +923,44 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
             </Button>
           </Tooltip>
         </FlexItem>
+        {showCreatePR && (
+          <>
+            <FlexItem>
+              <Button
+                variant="secondary"
+                icon={<UploadIcon />}
+                onClick={handleOpenRepoModal}
+                size="sm"
+              >
+                Load from Repo
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Tooltip
+                content="Submit quickstart YAML as a GitHub pull request"
+                position="top"
+              >
+                <Button
+                  variant="primary"
+                  icon={prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />}
+                  onClick={handleCreatePR}
+                  size="sm"
+                  isDisabled={!canCreatePR || prLoading}
+                  isLoading={prLoading}
+                >
+                  {prLoading ? 'Creating PR...' : 'Create PR'}
+                </Button>
+              </Tooltip>
+            </FlexItem>
+          </>
+        )}
+        {showCreatePR && parsedName && parsedName !== 'untitled-quickstart' && (
+          <FlexItem>
+            <Label color={isUpdate ? 'blue' : 'green'}>
+              {isUpdate ? 'Updating' : 'Creating'}: {parsedName}
+            </Label>
+          </FlexItem>
+        )}
       </Flex>
       {hasMetadataSelectors && (
         <Flex
@@ -819,6 +1008,72 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           }}
         />
       </div>
+      {showCreatePR && (
+        <Modal
+          isOpen={repoModalOpen}
+          onClose={() => setRepoModalOpen(false)}
+          aria-label="Load from Repository"
+          variant="medium"
+        >
+          <ModalHeader title="Load from Repository" />
+          <ModalBody>
+            <SearchInput
+              placeholder="Search quickstarts..."
+              value={repoSearch}
+              onChange={(_event, value) => setRepoSearch(value)}
+              onClear={() => setRepoSearch('')}
+              className="pf-v6-u-mb-md"
+            />
+            {repoLoading && <Spinner size="lg" />}
+            {repoError && (
+              <Alert variant="danger" title="Error" isInline>
+                {repoError}
+              </Alert>
+            )}
+            {!repoLoading && !repoError && (
+              <DataList aria-label="Repository quickstarts" isCompact>
+                {filteredRepoQuickstarts.map((qs) => (
+                  <DataListItem key={qs.name}>
+                    <DataListItemRow>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="name">
+                            <Button
+                              variant="link"
+                              isInline
+                              onClick={() => handleLoadFromRepo(qs.name)}
+                            >
+                              {qs.displayName || qs.name}
+                            </Button>
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                ))}
+                {filteredRepoQuickstarts.length === 0 && (
+                  <DataListItem key="empty">
+                    <DataListItemRow>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="empty-msg">
+                            No quickstarts found
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                )}
+              </DataList>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="link" onClick={() => setRepoModalOpen(false)}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
     </PageSection>
   );
 };

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -43,20 +43,17 @@ import {
   UploadIcon,
 } from '@patternfly/react-icons';
 import {
-  createQuickstartPR,
   getRepoQuickstartContent,
   listRepoQuickstarts,
-  quickstartExists,
-  PRResponse,
   RepoQuickstartEntry,
 } from '../../utils/createQuickstartPR';
 import Editor from '@monaco-editor/react';
 import YAML from 'yaml';
 import { QuickStartSpec } from '@patternfly/quickstarts';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { ExtendedQuickstart } from '../../utils/fetchQuickstarts';
 import { CreatorWizardContext } from './context';
+import { useCreatePR } from './useCreatePR';
 import { ALL_KIND_ENTRIES, ItemKind } from './meta';
 import { FilterData } from '../../utils/FiltersCategoryInterface';
 import './CreatorYAMLView.scss';
@@ -440,17 +437,23 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
   bundles: bundleOptions,
 }) => {
   const { files } = useContext(CreatorWizardContext);
-  const chrome = useChrome();
 
   // Hardcoded to true for local dev — revert to useFlag before opening PR:
   // const showCreatePR = useFlag('platform.learning-resources.quickstarts.create-pr');
   const showCreatePR = true;
 
-  const [prLoading, setPrLoading] = useState(false);
-  const [prResult, setPrResult] = useState<PRResponse | null>(null);
-  const [prError, setPrError] = useState<string | null>(null);
-  const [isUpdate, setIsUpdate] = useState(false);
   const [parsedName, setParsedName] = useState<string | null>(null);
+  const {
+    prLoading,
+    prResult,
+    prError,
+    isUpdate,
+    canCreatePR,
+    handleCreatePR,
+    setPrResult,
+    setPrError,
+  } = useCreatePR(parsedName);
+
   const [repoModalOpen, setRepoModalOpen] = useState(false);
   const [repoQuickstarts, setRepoQuickstarts] = useState<RepoQuickstartEntry[]>([]);
   const [repoLoading, setRepoLoading] = useState(false);
@@ -548,15 +551,9 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
       // Update state
       setParseError(null);
 
-      // Track parsed name for mode detection
       const name = metadata.name || null;
       if (name !== parsedName) {
         setParsedName(name);
-        if (name && name !== 'untitled-quickstart') {
-          quickstartExists(name).then(setIsUpdate);
-        } else {
-          setIsUpdate(false);
-        }
       }
 
       // Detect and propagate kind from spec.type
@@ -694,38 +691,6 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
     });
   };
 
-  const handleCreatePR = async () => {
-    if (!parsedName || prLoading) return;
-    setPrLoading(true);
-    setPrResult(null);
-    setPrError(null);
-    try {
-      const timestamp = Date.now();
-      const prefix = isUpdate ? 'update' : 'create';
-      let commitMessage = `feat(quickstarts): ${prefix} ${parsedName}`;
-      const user = await chrome.auth.getUser();
-      const identity = user?.identity?.user;
-      if (identity?.email) {
-        const name = [identity.first_name, identity.last_name].filter(Boolean).join(' ') || identity.email;
-        commitMessage += `\n\nCo-authored-by: ${name} <${identity.email}>`;
-      }
-      const result = await createQuickstartPR(files, {
-        branchName: `qs-${prefix}-${parsedName}-${timestamp}`,
-        commitMessage,
-        prTitle: `feat(quickstarts): ${prefix} ${parsedName}`,
-        prBody: `${isUpdate ? 'Updating' : 'Adding new'} quickstart via the Quickstarts Creator tool.\n\nDirectory: docs/quickstarts/${parsedName}/`,
-        isUpdate,
-        directoryName: parsedName,
-        ...(isUpdate ? { existingPath: `docs/quickstarts/${parsedName}/` } : {}),
-      });
-      setPrResult(result);
-    } catch (err) {
-      setPrError(err instanceof Error ? err.message : 'Failed to create PR');
-    } finally {
-      setPrLoading(false);
-    }
-  };
-
   const handleOpenRepoModal = async () => {
     setRepoModalOpen(true);
     setRepoLoading(true);
@@ -815,9 +780,6 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
 
   const canDownload =
     isUserContent(yamlContent) && !parseError && files.length > 0;
-
-  const canCreatePR =
-    canDownload && !!parsedName && parsedName !== 'untitled-quickstart';
 
   return (
     <PageSection className="lr-c-creator-yaml-view">
@@ -1005,7 +967,7 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
                 icon={prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />}
                 onClick={handleCreatePR}
                 size="sm"
-                isDisabled={!canCreatePR || prLoading}
+                isDisabled={!canCreatePR || !canDownload || prLoading}
                 isLoading={prLoading}
               >
                 {prLoading ? 'Creating PR...' : 'Create PR'}

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -443,8 +443,8 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
   const chrome = useChrome();
 
   // Hardcoded to true for local dev — revert to useFlag before opening PR:
-  const showCreatePR = useFlag('platform.learning-resources.quickstarts.create-pr');
-  // const showCreatePR = true;
+  // const showCreatePR = useFlag('platform.learning-resources.quickstarts.create-pr');
+  const showCreatePR = true;
 
   const [prLoading, setPrLoading] = useState(false);
   const [prResult, setPrResult] = useState<PRResponse | null>(null);
@@ -847,33 +847,6 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           </List>
         </Alert>
       )}
-      {prResult && (
-        <Alert
-          variant="success"
-          title="Pull Request Created"
-          className="pf-v6-u-mb-md"
-          isInline
-          actionClose={<Button variant="plain" onClick={() => setPrResult(null)}>✕</Button>}
-        >
-          <a href={prResult.prUrl} target="_blank" rel="noopener noreferrer">
-            {prResult.prUrl}
-          </a>
-        </Alert>
-      )}
-      {prError && (
-        <Alert
-          variant="danger"
-          title="Failed to Create PR"
-          className="pf-v6-u-mb-md"
-          isInline
-          actionClose={<Button variant="plain" onClick={() => setPrError(null)}>✕</Button>}
-        >
-          {prError}{' '}
-          <Button variant="link" isInline onClick={handleCreatePR}>
-            Retry
-          </Button>
-        </Alert>
-      )}
       <Flex
         spaceItems={{ default: 'spaceItemsSm' }}
         className="lr-c-creator-yaml-view__toolbar"
@@ -907,52 +880,17 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
             data-testid="yaml-file-input"
           />
         </FlexItem>
-        <FlexItem>
-          <Tooltip
-            content="Download metadata.yaml and quickstart YAML files, same as wizard"
-            position="top"
-          >
-            <Button
-              variant="primary"
-              icon={<DownloadIcon />}
-              onClick={handleDownload}
-              size="sm"
-              isDisabled={!canDownload}
-            >
-              Download Files ({files.length})
-            </Button>
-          </Tooltip>
-        </FlexItem>
         {showCreatePR && (
-          <>
-            <FlexItem>
-              <Button
-                variant="secondary"
-                icon={<UploadIcon />}
-                onClick={handleOpenRepoModal}
-                size="sm"
-              >
-                Load from Repo
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Tooltip
-                content="Submit quickstart YAML as a GitHub pull request"
-                position="top"
-              >
-                <Button
-                  variant="primary"
-                  icon={prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />}
-                  onClick={handleCreatePR}
-                  size="sm"
-                  isDisabled={!canCreatePR || prLoading}
-                  isLoading={prLoading}
-                >
-                  {prLoading ? 'Creating PR...' : 'Create PR'}
-                </Button>
-              </Tooltip>
-            </FlexItem>
-          </>
+          <FlexItem>
+            <Button
+              variant="secondary"
+              icon={<UploadIcon />}
+              onClick={handleOpenRepoModal}
+              size="sm"
+            >
+              Load from Repo
+            </Button>
+          </FlexItem>
         )}
         {showCreatePR && parsedName && parsedName !== 'untitled-quickstart' && (
           <FlexItem>
@@ -1008,6 +946,74 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           }}
         />
       </div>
+      {prResult && (
+        <Alert
+          variant="success"
+          title="Pull Request Created"
+          className="pf-v6-u-mb-md"
+          isInline
+          actionClose={<Button variant="plain" onClick={() => setPrResult(null)}>✕</Button>}
+        >
+          <a href={prResult.prUrl} target="_blank" rel="noopener noreferrer">
+            {prResult.prUrl}
+          </a>
+        </Alert>
+      )}
+      {prError && (
+        <Alert
+          variant="danger"
+          title="Failed to Create PR"
+          className="pf-v6-u-mb-md"
+          isInline
+          actionClose={<Button variant="plain" onClick={() => setPrError(null)}>✕</Button>}
+        >
+          {prError}{' '}
+          <Button variant="link" isInline onClick={handleCreatePR}>
+            Retry
+          </Button>
+        </Alert>
+      )}
+      <Flex
+        spaceItems={{ default: 'spaceItemsSm' }}
+        className="lr-c-creator-yaml-view__toolbar"
+        alignItems={{ default: 'alignItemsCenter' }}
+      >
+        <FlexItem>
+          <Tooltip
+            content="Download metadata.yaml and quickstart YAML files, same as wizard"
+            position="top"
+          >
+            <Button
+              variant="primary"
+              icon={<DownloadIcon />}
+              onClick={handleDownload}
+              size="sm"
+              isDisabled={!canDownload}
+            >
+              Download Files ({files.length})
+            </Button>
+          </Tooltip>
+        </FlexItem>
+        {showCreatePR && (
+          <FlexItem>
+            <Tooltip
+              content="Submit quickstart YAML as a GitHub pull request"
+              position="top"
+            >
+              <Button
+                variant="primary"
+                icon={prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />}
+                onClick={handleCreatePR}
+                size="sm"
+                isDisabled={!canCreatePR || prLoading}
+                isLoading={prLoading}
+              >
+                {prLoading ? 'Creating PR...' : 'Create PR'}
+              </Button>
+            </Tooltip>
+          </FlexItem>
+        )}
+      </Flex>
       {showCreatePR && (
         <Modal
           isOpen={repoModalOpen}

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -57,6 +57,7 @@ import { useCreatePR } from './useCreatePR';
 import { ALL_KIND_ENTRIES, ItemKind } from './meta';
 import { FilterData } from '../../utils/FiltersCategoryInterface';
 import { useFlag } from '@unleash/proxy-client-react';
+import CreatePRModal from './CreatePRModal';
 import './CreatorYAMLView.scss';
 import { DEFAULT_QUICKSTART_YAML } from '../../data/quickstart-templates';
 
@@ -453,6 +454,18 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
     setPrResult,
     setPrError,
   } = useCreatePR(parsedName);
+
+  const [prModalOpen, setPrModalOpen] = useState(false);
+
+  const handleOpenPRModal = () => {
+    setPrResult(null);
+    setPrError(null);
+    setPrModalOpen(true);
+  };
+
+  const handleClosePRModal = () => {
+    setPrModalOpen(false);
+  };
 
   const [repoModalOpen, setRepoModalOpen] = useState(false);
   const [repoQuickstarts, setRepoQuickstarts] = useState<RepoQuickstartEntry[]>(
@@ -951,41 +964,6 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           }}
         />
       </div>
-      {showCreatePR && prResult && (
-        <Alert
-          variant="success"
-          title="Pull Request Created"
-          className="pf-v6-u-mb-md"
-          isInline
-          actionClose={
-            <Button variant="plain" onClick={() => setPrResult(null)}>
-              ✕
-            </Button>
-          }
-        >
-          <a href={prResult.prUrl} target="_blank" rel="noopener noreferrer">
-            {prResult.prUrl}
-          </a>
-        </Alert>
-      )}
-      {showCreatePR && prError && (
-        <Alert
-          variant="danger"
-          title="Failed to Create PR"
-          className="pf-v6-u-mb-md"
-          isInline
-          actionClose={
-            <Button variant="plain" onClick={() => setPrError(null)}>
-              ✕
-            </Button>
-          }
-        >
-          {prError}{' '}
-          <Button variant="link" isInline onClick={handleCreatePR}>
-            Retry
-          </Button>
-        </Alert>
-      )}
       {showCreatePR && (
         <Flex
           spaceItems={{ default: 'spaceItemsSm' }}
@@ -1015,17 +993,27 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
             >
               <Button
                 variant="primary"
-                icon={prLoading ? undefined : <CodeBranchIcon />}
-                onClick={handleCreatePR}
+                icon={<CodeBranchIcon />}
+                onClick={handleOpenPRModal}
                 size="sm"
-                isDisabled={!canCreatePR || !canDownload || prLoading}
-                isLoading={prLoading}
+                isDisabled={!canCreatePR || !canDownload}
               >
-                {prLoading ? 'Creating PR...' : 'Create PR'}
+                Create PR
               </Button>
             </Tooltip>
           </FlexItem>
         </Flex>
+      )}
+      {showCreatePR && parsedName && (
+        <CreatePRModal
+          isOpen={prModalOpen}
+          onClose={handleClosePRModal}
+          onConfirm={handleCreatePR}
+          quickstartName={parsedName}
+          prLoading={prLoading}
+          prResult={prResult}
+          prError={prError}
+        />
       )}
       {showCreatePR && (
         <Modal

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -448,7 +448,6 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
     prLoading,
     prResult,
     prError,
-    isUpdate,
     canCreatePR,
     handleCreatePR,
     setPrResult,
@@ -902,9 +901,7 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
         )}
         {showCreatePR && parsedName && parsedName !== 'untitled-quickstart' && (
           <FlexItem>
-            <Label color={isUpdate ? 'blue' : 'green'}>
-              {isUpdate ? 'Updating' : 'Creating'}: {parsedName}
-            </Label>
+            <Label color="blue">Editing: {parsedName}</Label>
           </FlexItem>
         )}
       </Flex>

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -223,9 +223,6 @@ function serializeToYaml(
       ...(quickStart.spec.description
         ? { description: quickStart.spec.description }
         : {}),
-      ...(quickStart.spec.durationMinutes !== undefined
-        ? { durationMinutes: quickStart.spec.durationMinutes }
-        : {}),
       ...(quickStart.spec.type
         ? {
             type: {
@@ -233,6 +230,9 @@ function serializeToYaml(
               color: quickStart.spec.type.color,
             },
           }
+        : {}),
+      ...(quickStart.spec.durationMinutes !== undefined
+        ? { durationMinutes: quickStart.spec.durationMinutes }
         : {}),
       ...(quickStart.spec.link
         ? {
@@ -498,6 +498,15 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
     yamlContentRef.current = yamlContent;
   }, [yamlContent]);
 
+  // Parse initial YAML on mount so parsedName is set when wizard data is present
+  const initialYamlRef = useRef(true);
+  useEffect(() => {
+    if (initialYamlRef.current && isUserContent(yamlContent)) {
+      parseAndUpdateQuickstart(yamlContent);
+    }
+    initialYamlRef.current = false;
+  }, []);
+
   const configureMonacoEnvironment = () => {
     // Disable Monaco workers to prevent CDN fetching in CI environments
     self.MonacoEnvironment = {
@@ -716,8 +725,21 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           f.name !== 'metadata.yaml'
       );
       if (yamlFile) {
-        setYamlContent(yamlFile.content);
-        parseAndUpdateQuickstart(yamlFile.content);
+        let finalContent = yamlFile.content;
+        try {
+          const parsed = YAML.parse(finalContent);
+          if (parsed && !parsed.kind) {
+            const { metadata, spec, ...rest } = parsed;
+            finalContent = YAML.stringify(
+              { kind: 'QuickStarts', metadata, spec, ...rest },
+              { lineWidth: 0 }
+            );
+          }
+        } catch {
+          // use raw content if parse fails
+        }
+        setYamlContent(finalContent);
+        parseAndUpdateQuickstart(finalContent);
       }
     } catch (err) {
       setParseError(err instanceof Error ? err.message : 'Failed to load quickstart');

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -56,6 +56,7 @@ import { CreatorWizardContext } from './context';
 import { useCreatePR } from './useCreatePR';
 import { ALL_KIND_ENTRIES, ItemKind } from './meta';
 import { FilterData } from '../../utils/FiltersCategoryInterface';
+import { useFlag } from '@unleash/proxy-client-react';
 import './CreatorYAMLView.scss';
 import { DEFAULT_QUICKSTART_YAML } from '../../data/quickstart-templates';
 
@@ -438,9 +439,7 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
 }) => {
   const { files } = useContext(CreatorWizardContext);
 
-  // Hardcoded to true for local dev — revert to useFlag before opening PR:
-  // const showCreatePR = useFlag('platform.learning-resources.quickstarts.create-pr');
-  const showCreatePR = true;
+  const showCreatePR = useFlag('platform.learning-resources.quickstarts.git-service');
 
   const [parsedName, setParsedName] = useState<string | null>(null);
   const {
@@ -834,7 +833,6 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
       <Flex
         spaceItems={{ default: 'spaceItemsSm' }}
         className="lr-c-creator-yaml-view__toolbar"
-        alignItems={{ default: 'alignItemsCenter' }}
       >
         <FlexItem>
           <Button
@@ -864,6 +862,24 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
             data-testid="yaml-file-input"
           />
         </FlexItem>
+        {!showCreatePR && (
+          <FlexItem>
+            <Tooltip
+              content="Download metadata.yaml and quickstart YAML files, same as wizard"
+              position="top"
+            >
+              <Button
+                variant="primary"
+                icon={<DownloadIcon />}
+                onClick={handleDownload}
+                size="sm"
+                isDisabled={!canDownload}
+              >
+                Download Files ({files.length})
+              </Button>
+            </Tooltip>
+          </FlexItem>
+        )}
         {showCreatePR && (
           <FlexItem>
             <Button
@@ -930,7 +946,7 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           }}
         />
       </div>
-      {prResult && (
+      {showCreatePR && prResult && (
         <Alert
           variant="success"
           title="Pull Request Created"
@@ -943,7 +959,7 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           </a>
         </Alert>
       )}
-      {prError && (
+      {showCreatePR && prError && (
         <Alert
           variant="danger"
           title="Failed to Create PR"
@@ -957,28 +973,28 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           </Button>
         </Alert>
       )}
-      <Flex
-        spaceItems={{ default: 'spaceItemsSm' }}
-        className="lr-c-creator-yaml-view__toolbar"
-        alignItems={{ default: 'alignItemsCenter' }}
-      >
-        <FlexItem>
-          <Tooltip
-            content="Download metadata.yaml and quickstart YAML files, same as wizard"
-            position="top"
-          >
-            <Button
-              variant="primary"
-              icon={<DownloadIcon />}
-              onClick={handleDownload}
-              size="sm"
-              isDisabled={!canDownload}
+      {showCreatePR && (
+        <Flex
+          spaceItems={{ default: 'spaceItemsSm' }}
+          className="lr-c-creator-yaml-view__toolbar"
+          alignItems={{ default: 'alignItemsCenter' }}
+        >
+          <FlexItem>
+            <Tooltip
+              content="Download metadata.yaml and quickstart YAML files, same as wizard"
+              position="top"
             >
-              Download Files ({files.length})
-            </Button>
-          </Tooltip>
-        </FlexItem>
-        {showCreatePR && (
+              <Button
+                variant="primary"
+                icon={<DownloadIcon />}
+                onClick={handleDownload}
+                size="sm"
+                isDisabled={!canDownload}
+              >
+                Download Files ({files.length})
+              </Button>
+            </Tooltip>
+          </FlexItem>
           <FlexItem>
             <Tooltip
               content="Submit quickstart YAML as a GitHub pull request"
@@ -986,7 +1002,7 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
             >
               <Button
                 variant="primary"
-                icon={prLoading ? <Spinner size="sm" /> : <CodeBranchIcon />}
+                icon={prLoading ? undefined : <CodeBranchIcon />}
                 onClick={handleCreatePR}
                 size="sm"
                 isDisabled={!canCreatePR || !canDownload || prLoading}
@@ -996,8 +1012,8 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
               </Button>
             </Tooltip>
           </FlexItem>
-        )}
-      </Flex>
+        </Flex>
+      )}
       {showCreatePR && (
         <Modal
           isOpen={repoModalOpen}

--- a/src/components/creator/CreatorYAMLView.tsx
+++ b/src/components/creator/CreatorYAMLView.tsx
@@ -43,9 +43,9 @@ import {
   UploadIcon,
 } from '@patternfly/react-icons';
 import {
+  RepoQuickstartEntry,
   getRepoQuickstartContent,
   listRepoQuickstarts,
-  RepoQuickstartEntry,
 } from '../../utils/createQuickstartPR';
 import Editor from '@monaco-editor/react';
 import YAML from 'yaml';
@@ -439,7 +439,9 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
 }) => {
   const { files } = useContext(CreatorWizardContext);
 
-  const showCreatePR = useFlag('platform.learning-resources.quickstarts.git-service');
+  const showCreatePR = useFlag(
+    'platform.learning-resources.quickstarts.git-service'
+  );
 
   const [parsedName, setParsedName] = useState<string | null>(null);
   const {
@@ -454,7 +456,9 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
   } = useCreatePR(parsedName);
 
   const [repoModalOpen, setRepoModalOpen] = useState(false);
-  const [repoQuickstarts, setRepoQuickstarts] = useState<RepoQuickstartEntry[]>([]);
+  const [repoQuickstarts, setRepoQuickstarts] = useState<RepoQuickstartEntry[]>(
+    []
+  );
   const [repoLoading, setRepoLoading] = useState(false);
   const [repoSearch, setRepoSearch] = useState('');
   const [repoError, setRepoError] = useState<string | null>(null);
@@ -708,7 +712,9 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
       const entries = await listRepoQuickstarts();
       setRepoQuickstarts(entries);
     } catch (err) {
-      setRepoError(err instanceof Error ? err.message : 'Failed to load quickstarts');
+      setRepoError(
+        err instanceof Error ? err.message : 'Failed to load quickstarts'
+      );
     } finally {
       setRepoLoading(false);
     }
@@ -741,7 +747,9 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
         parseAndUpdateQuickstart(finalContent);
       }
     } catch (err) {
-      setParseError(err instanceof Error ? err.message : 'Failed to load quickstart');
+      setParseError(
+        err instanceof Error ? err.message : 'Failed to load quickstart'
+      );
     }
   };
 
@@ -952,7 +960,11 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           title="Pull Request Created"
           className="pf-v6-u-mb-md"
           isInline
-          actionClose={<Button variant="plain" onClick={() => setPrResult(null)}>✕</Button>}
+          actionClose={
+            <Button variant="plain" onClick={() => setPrResult(null)}>
+              ✕
+            </Button>
+          }
         >
           <a href={prResult.prUrl} target="_blank" rel="noopener noreferrer">
             {prResult.prUrl}
@@ -965,7 +977,11 @@ const CreatorYAMLView: React.FC<CreatorYAMLViewProps> = ({
           title="Failed to Create PR"
           className="pf-v6-u-mb-md"
           isInline
-          actionClose={<Button variant="plain" onClick={() => setPrError(null)}>✕</Button>}
+          actionClose={
+            <Button variant="plain" onClick={() => setPrError(null)}>
+              ✕
+            </Button>
+          }
         >
           {prError}{' '}
           <Button variant="link" isInline onClick={handleCreatePR}>

--- a/src/components/creator/SourceSelector.tsx
+++ b/src/components/creator/SourceSelector.tsx
@@ -1,0 +1,312 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  SearchInput,
+  Spinner,
+  Content,
+} from '@patternfly/react-core';
+import {
+  UseFieldApiConfig,
+  useFieldApi,
+  useFormApi,
+} from '@data-driven-forms/react-form-renderer';
+import YAML from 'yaml';
+import {
+  listRepoQuickstarts,
+  getRepoQuickstartContent,
+  RepoQuickstartEntry,
+} from '../../utils/createQuickstartPR';
+import {
+  NAME_KIND,
+  NAME_METADATA_NAME,
+  NAME_TITLE,
+  NAME_DESCRIPTION,
+  NAME_DURATION,
+  NAME_URL,
+  NAME_BUNDLES,
+  NAME_TAGS,
+  NAME_PANEL_INTRODUCTION,
+  NAME_PREREQUISITES,
+  NAME_TASK_TITLES,
+  NAME_TASKS_ARRAY,
+} from './steps/common';
+import { ALL_KIND_ENTRIES, ItemKind } from './meta';
+
+const SOURCE_SCRATCH = '__scratch__';
+
+const normalizeKindLabel = (value: string) =>
+  value.toLowerCase().replace(/\s+/g, '');
+
+function detectKindFromSpec(
+  spec: Record<string, unknown> | undefined
+): ItemKind | null {
+  const typeObj = spec?.type as Record<string, unknown> | undefined;
+  const typeText = typeObj?.text;
+  if (typeof typeText !== 'string') return null;
+  for (const [kind, meta] of ALL_KIND_ENTRIES) {
+    if (normalizeKindLabel(meta.displayName) === normalizeKindLabel(typeText)) {
+      return kind;
+    }
+  }
+  return null;
+}
+
+const SourceSelector = (props: UseFieldApiConfig) => {
+  const { input } = useFieldApi(props);
+  const formApi = useFormApi();
+
+  const [quickstarts, setQuickstarts] = useState<RepoQuickstartEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [loadingName, setLoadingName] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const entries = await listRepoQuickstarts();
+        if (!cancelled) setQuickstarts(entries);
+      } catch (err) {
+        if (!cancelled)
+          setError(
+            err instanceof Error ? err.message : 'Failed to load quickstarts'
+          );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(
+    () =>
+      quickstarts.filter(
+        (qs) =>
+          qs.name.toLowerCase().includes(search.toLowerCase()) ||
+          qs.displayName.toLowerCase().includes(search.toLowerCase())
+      ),
+    [quickstarts, search]
+  );
+
+  const handleSelectScratch = () => {
+    input.onChange(SOURCE_SCRATCH);
+    formApi.change(NAME_KIND, undefined);
+    formApi.change(NAME_METADATA_NAME, undefined);
+    formApi.change(NAME_TITLE, undefined);
+    formApi.change(NAME_DESCRIPTION, undefined);
+    formApi.change(NAME_DURATION, undefined);
+    formApi.change(NAME_URL, undefined);
+    formApi.change(NAME_BUNDLES, undefined);
+    formApi.change(NAME_TAGS, undefined);
+    formApi.change(NAME_PREREQUISITES, undefined);
+    formApi.change(NAME_PANEL_INTRODUCTION, undefined);
+    formApi.change(NAME_TASK_TITLES, undefined);
+    formApi.change(NAME_TASKS_ARRAY, undefined);
+  };
+
+  const handleSelectRepo = async (name: string) => {
+    setLoadingName(name);
+    input.onChange(name);
+    try {
+      const content = await getRepoQuickstartContent(name);
+      const yamlFile = content.files.find(
+        (f) =>
+          (f.name.endsWith('.yml') || f.name.endsWith('.yaml')) &&
+          f.name !== 'metadata.yaml'
+      );
+      if (!yamlFile) return;
+
+      const parsed = YAML.parse(yamlFile.content);
+      if (!parsed) return;
+
+      const spec = parsed.spec || {};
+      const metadata = parsed.metadata || {};
+
+      if (metadata.name) formApi.change(NAME_METADATA_NAME, metadata.name);
+
+      const detectedKind = detectKindFromSpec(spec);
+      if (detectedKind) {
+        formApi.change(NAME_KIND, detectedKind);
+      }
+
+      if (spec.displayName) formApi.change(NAME_TITLE, spec.displayName);
+      if (spec.description) formApi.change(NAME_DESCRIPTION, spec.description);
+      if (spec.durationMinutes !== undefined)
+        formApi.change(NAME_DURATION, spec.durationMinutes);
+      if (spec.link?.href) formApi.change(NAME_URL, spec.link.href);
+      if (spec.prerequisites)
+        formApi.change(NAME_PREREQUISITES, spec.prerequisites);
+      if (spec.introduction)
+        formApi.change(NAME_PANEL_INTRODUCTION, spec.introduction);
+
+      if (spec.tasks && Array.isArray(spec.tasks)) {
+        formApi.change(
+          NAME_TASK_TITLES,
+          spec.tasks.map((t: { title?: string }) => t.title || '')
+        );
+        formApi.change(
+          NAME_TASKS_ARRAY,
+          spec.tasks.map(
+            (t: {
+              description?: string;
+              review?: {
+                instructions?: string;
+                failedTaskHelp?: string;
+              };
+            }) => ({
+              description: t.description,
+              enable_work_check: !!t.review,
+              work_check_instructions: t.review?.instructions,
+              work_check_help: t.review?.failedTaskHelp,
+            })
+          )
+        );
+      }
+
+      const bundles: string[] = [];
+      const tagsByKind: { [kind: string]: string[] } = {};
+      if (Array.isArray(metadata.tags)) {
+        metadata.tags.forEach((tag: { kind?: string; value?: string }) => {
+          if (tag.kind === 'bundle' && tag.value) {
+            bundles.push(tag.value);
+          } else if (tag.kind && tag.value) {
+            if (!tagsByKind[tag.kind]) tagsByKind[tag.kind] = [];
+            tagsByKind[tag.kind].push(tag.value);
+          }
+        });
+      }
+      if (bundles.length > 0) formApi.change(NAME_BUNDLES, bundles);
+      if (Object.keys(tagsByKind).length > 0)
+        formApi.change(NAME_TAGS, tagsByKind);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to load quickstart'
+      );
+    } finally {
+      setLoadingName(null);
+    }
+  };
+
+  const selected = input.value;
+
+  return (
+    <div>
+      <div className="pf-v6-c-form__group">
+        <Content component="p">
+          Start from scratch or load an existing quickstart from the repository.
+        </Content>
+      </div>
+      <div className="pf-v6-c-form__group">
+        <label className="pf-v6-c-form__label">
+          <span className="pf-v6-c-form__label-text">Select source</span>
+          <span className="pf-v6-c-form__label-required" aria-hidden="true"> *</span>
+        </label>
+        <div className="pf-v6-c-form__group-control">
+
+      <SearchInput
+        placeholder="Search quickstarts..."
+        value={search}
+        onChange={(_event, value) => setSearch(value)}
+        onClear={() => setSearch('')}
+        className="pf-v6-u-mb-sm"
+      />
+
+      {loading && <Spinner size="lg" className="pf-v6-u-mt-md" />}
+
+      {error && (
+        <Alert variant="danger" title="Error" isInline className="pf-v6-u-mt-md">
+          {error}
+        </Alert>
+      )}
+
+      {!loading && !error && (
+        <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+          <DataList aria-label="Source selection" isCompact>
+            <DataListItem
+              key="scratch"
+              aria-labelledby="source-scratch"
+              className={selected === SOURCE_SCRATCH ? 'pf-m-selected' : ''}
+            >
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={[
+                    <DataListCell key="name">
+                      <button
+                        id="source-scratch"
+                        type="button"
+                        className={`pf-v6-c-button pf-m-link pf-m-inline${
+                          selected === SOURCE_SCRATCH ? ' pf-m-current' : ''
+                        }`}
+                        onClick={handleSelectScratch}
+                        style={{ fontWeight: selected === SOURCE_SCRATCH ? 700 : 400 }}
+                      >
+                        Start from scratch
+                      </button>
+                    </DataListCell>,
+                  ]}
+                />
+              </DataListItemRow>
+            </DataListItem>
+            {filtered.map((qs) => (
+              <DataListItem
+                key={qs.name}
+                aria-labelledby={`source-${qs.name}`}
+                className={selected === qs.name ? 'pf-m-selected' : ''}
+              >
+                <DataListItemRow>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key="name">
+                        <button
+                          id={`source-${qs.name}`}
+                          type="button"
+                          className={`pf-v6-c-button pf-m-link pf-m-inline${
+                            selected === qs.name ? ' pf-m-current' : ''
+                          }`}
+                          onClick={() => handleSelectRepo(qs.name)}
+                          disabled={loadingName !== null}
+                          style={{ fontWeight: selected === qs.name ? 700 : 400 }}
+                        >
+                          {qs.displayName || qs.name}
+                          {loadingName === qs.name && (
+                            <Spinner size="sm" className="pf-v6-u-ml-sm" />
+                          )}
+                        </button>
+                      </DataListCell>,
+                    ]}
+                  />
+                </DataListItemRow>
+              </DataListItem>
+            ))}
+            {filtered.length === 0 && quickstarts.length > 0 && (
+              <DataListItem key="empty">
+                <DataListItemRow>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key="empty-msg">
+                        No quickstarts found
+                      </DataListCell>,
+                    ]}
+                  />
+                </DataListItemRow>
+              </DataListItem>
+            )}
+          </DataList>
+        </div>
+      )}
+
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SourceSelector;

--- a/src/components/creator/SourceSelector.tsx
+++ b/src/components/creator/SourceSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
+  Content,
   DataList,
   DataListCell,
   DataListItem,
@@ -8,7 +9,6 @@ import {
   DataListItemRow,
   SearchInput,
   Spinner,
-  Content,
 } from '@patternfly/react-core';
 import {
   UseFieldApiConfig,
@@ -17,23 +17,23 @@ import {
 } from '@data-driven-forms/react-form-renderer';
 import YAML from 'yaml';
 import {
-  listRepoQuickstarts,
-  getRepoQuickstartContent,
   RepoQuickstartEntry,
+  getRepoQuickstartContent,
+  listRepoQuickstarts,
 } from '../../utils/createQuickstartPR';
 import {
-  NAME_KIND,
-  NAME_METADATA_NAME,
-  NAME_TITLE,
+  NAME_BUNDLES,
   NAME_DESCRIPTION,
   NAME_DURATION,
-  NAME_URL,
-  NAME_BUNDLES,
-  NAME_TAGS,
+  NAME_KIND,
+  NAME_METADATA_NAME,
   NAME_PANEL_INTRODUCTION,
   NAME_PREREQUISITES,
-  NAME_TASK_TITLES,
+  NAME_TAGS,
   NAME_TASKS_ARRAY,
+  NAME_TASK_TITLES,
+  NAME_TITLE,
+  NAME_URL,
 } from './steps/common';
 import { ALL_KIND_ENTRIES, ItemKind } from './meta';
 
@@ -207,102 +207,113 @@ const SourceSelector = (props: UseFieldApiConfig) => {
       <div className="pf-v6-c-form__group">
         <label className="pf-v6-c-form__label">
           <span className="pf-v6-c-form__label-text">Select source</span>
-          <span className="pf-v6-c-form__label-required" aria-hidden="true"> *</span>
+          <span className="pf-v6-c-form__label-required" aria-hidden="true">
+            {' '}
+            *
+          </span>
         </label>
         <div className="pf-v6-c-form__group-control">
+          <SearchInput
+            placeholder="Search quickstarts..."
+            value={search}
+            onChange={(_event, value) => setSearch(value)}
+            onClear={() => setSearch('')}
+            className="pf-v6-u-mb-sm"
+          />
 
-      <SearchInput
-        placeholder="Search quickstarts..."
-        value={search}
-        onChange={(_event, value) => setSearch(value)}
-        onClear={() => setSearch('')}
-        className="pf-v6-u-mb-sm"
-      />
+          {loading && <Spinner size="lg" className="pf-v6-u-mt-md" />}
 
-      {loading && <Spinner size="lg" className="pf-v6-u-mt-md" />}
-
-      {error && (
-        <Alert variant="danger" title="Error" isInline className="pf-v6-u-mt-md">
-          {error}
-        </Alert>
-      )}
-
-      {!loading && !error && (
-        <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
-          <DataList aria-label="Source selection" isCompact>
-            <DataListItem
-              key="scratch"
-              aria-labelledby="source-scratch"
-              className={selected === SOURCE_SCRATCH ? 'pf-m-selected' : ''}
+          {error && (
+            <Alert
+              variant="danger"
+              title="Error"
+              isInline
+              className="pf-v6-u-mt-md"
             >
-              <DataListItemRow>
-                <DataListItemCells
-                  dataListCells={[
-                    <DataListCell key="name">
-                      <button
-                        id="source-scratch"
-                        type="button"
-                        className={`pf-v6-c-button pf-m-link pf-m-inline${
-                          selected === SOURCE_SCRATCH ? ' pf-m-current' : ''
-                        }`}
-                        onClick={handleSelectScratch}
-                        style={{ fontWeight: selected === SOURCE_SCRATCH ? 700 : 400 }}
-                      >
-                        Start from scratch
-                      </button>
-                    </DataListCell>,
-                  ]}
-                />
-              </DataListItemRow>
-            </DataListItem>
-            {filtered.map((qs) => (
-              <DataListItem
-                key={qs.name}
-                aria-labelledby={`source-${qs.name}`}
-                className={selected === qs.name ? 'pf-m-selected' : ''}
-              >
-                <DataListItemRow>
-                  <DataListItemCells
-                    dataListCells={[
-                      <DataListCell key="name">
-                        <button
-                          id={`source-${qs.name}`}
-                          type="button"
-                          className={`pf-v6-c-button pf-m-link pf-m-inline${
-                            selected === qs.name ? ' pf-m-current' : ''
-                          }`}
-                          onClick={() => handleSelectRepo(qs.name)}
-                          disabled={loadingName !== null}
-                          style={{ fontWeight: selected === qs.name ? 700 : 400 }}
-                        >
-                          {qs.displayName || qs.name}
-                          {loadingName === qs.name && (
-                            <Spinner size="sm" className="pf-v6-u-ml-sm" />
-                          )}
-                        </button>
-                      </DataListCell>,
-                    ]}
-                  />
-                </DataListItemRow>
-              </DataListItem>
-            ))}
-            {filtered.length === 0 && quickstarts.length > 0 && (
-              <DataListItem key="empty">
-                <DataListItemRow>
-                  <DataListItemCells
-                    dataListCells={[
-                      <DataListCell key="empty-msg">
-                        No quickstarts found
-                      </DataListCell>,
-                    ]}
-                  />
-                </DataListItemRow>
-              </DataListItem>
-            )}
-          </DataList>
-        </div>
-      )}
+              {error}
+            </Alert>
+          )}
 
+          {!loading && !error && (
+            <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+              <DataList aria-label="Source selection" isCompact>
+                <DataListItem
+                  key="scratch"
+                  aria-labelledby="source-scratch"
+                  className={selected === SOURCE_SCRATCH ? 'pf-m-selected' : ''}
+                >
+                  <DataListItemRow>
+                    <DataListItemCells
+                      dataListCells={[
+                        <DataListCell key="name">
+                          <button
+                            id="source-scratch"
+                            type="button"
+                            className={`pf-v6-c-button pf-m-link pf-m-inline${
+                              selected === SOURCE_SCRATCH ? ' pf-m-current' : ''
+                            }`}
+                            onClick={handleSelectScratch}
+                            style={{
+                              fontWeight:
+                                selected === SOURCE_SCRATCH ? 700 : 400,
+                            }}
+                          >
+                            Start from scratch
+                          </button>
+                        </DataListCell>,
+                      ]}
+                    />
+                  </DataListItemRow>
+                </DataListItem>
+                {filtered.map((qs) => (
+                  <DataListItem
+                    key={qs.name}
+                    aria-labelledby={`source-${qs.name}`}
+                    className={selected === qs.name ? 'pf-m-selected' : ''}
+                  >
+                    <DataListItemRow>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="name">
+                            <button
+                              id={`source-${qs.name}`}
+                              type="button"
+                              className={`pf-v6-c-button pf-m-link pf-m-inline${
+                                selected === qs.name ? ' pf-m-current' : ''
+                              }`}
+                              onClick={() => handleSelectRepo(qs.name)}
+                              disabled={loadingName !== null}
+                              style={{
+                                fontWeight: selected === qs.name ? 700 : 400,
+                              }}
+                            >
+                              {qs.displayName || qs.name}
+                              {loadingName === qs.name && (
+                                <Spinner size="sm" className="pf-v6-u-ml-sm" />
+                              )}
+                            </button>
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                ))}
+                {filtered.length === 0 && quickstarts.length > 0 && (
+                  <DataListItem key="empty">
+                    <DataListItemRow>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="empty-msg">
+                            No quickstarts found
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                )}
+              </DataList>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/creator/SourceSelector.tsx
+++ b/src/components/creator/SourceSelector.tsx
@@ -86,18 +86,16 @@ const SourceSelector = (props: UseFieldApiConfig) => {
     };
   }, []);
 
-  const filtered = useMemo(
-    () =>
-      quickstarts.filter(
-        (qs) =>
-          qs.name.toLowerCase().includes(search.toLowerCase()) ||
-          qs.displayName.toLowerCase().includes(search.toLowerCase())
-      ),
-    [quickstarts, search]
-  );
+  const filtered = useMemo(() => {
+    const needle = search.toLowerCase();
+    return quickstarts.filter(
+      (qs) =>
+        (qs.name ?? '').toLowerCase().includes(needle) ||
+        (qs.displayName ?? '').toLowerCase().includes(needle)
+    );
+  }, [quickstarts, search]);
 
-  const handleSelectScratch = () => {
-    input.onChange(SOURCE_SCRATCH);
+  const clearQuickstartFields = () => {
     formApi.change(NAME_KIND, undefined);
     formApi.change(NAME_METADATA_NAME, undefined);
     formApi.change(NAME_TITLE, undefined);
@@ -112,9 +110,16 @@ const SourceSelector = (props: UseFieldApiConfig) => {
     formApi.change(NAME_TASKS_ARRAY, undefined);
   };
 
+  const handleSelectScratch = () => {
+    input.onChange(SOURCE_SCRATCH);
+    clearQuickstartFields();
+  };
+
   const handleSelectRepo = async (name: string) => {
     setLoadingName(name);
     input.onChange(name);
+    setError(null);
+    clearQuickstartFields();
     try {
       const content = await getRepoQuickstartContent(name);
       const yamlFile = content.files.find(
@@ -122,10 +127,16 @@ const SourceSelector = (props: UseFieldApiConfig) => {
           (f.name.endsWith('.yml') || f.name.endsWith('.yaml')) &&
           f.name !== 'metadata.yaml'
       );
-      if (!yamlFile) return;
+      if (!yamlFile) {
+        setError(`No quickstart YAML file found in "${name}".`);
+        return;
+      }
 
       const parsed = YAML.parse(yamlFile.content);
-      if (!parsed) return;
+      if (!parsed) {
+        setError(`The quickstart YAML in "${name}" is empty or not valid.`);
+        return;
+      }
 
       const spec = parsed.spec || {};
       const metadata = parsed.metadata || {};

--- a/src/components/creator/meta.ts
+++ b/src/components/creator/meta.ts
@@ -12,7 +12,7 @@ const rawItemKindMeta = Object.freeze({
     },
   },
   quickstart: {
-    displayName: 'Quickstart',
+    displayName: 'Quick start',
     tagColor: 'green',
     hasDuration: true,
     fields: {

--- a/src/components/creator/schema.tsx
+++ b/src/components/creator/schema.tsx
@@ -91,7 +91,11 @@ export function stageFromStepName(name: string): CreatorWizardStage {
   throw new Error('unable to parse step name: ' + name);
 }
 
-export function makeSchema(chrome: ChromeAPI, filterData: FilterData, showGitService = false): Schema {
+export function makeSchema(
+  chrome: ChromeAPI,
+  filterData: FilterData,
+  showGitService = false
+): Schema {
   const bundles = chrome.getAvailableBundles();
 
   const taskSteps = [];

--- a/src/components/creator/schema.tsx
+++ b/src/components/creator/schema.tsx
@@ -18,6 +18,7 @@ import {
   makePanelOverviewStep,
 } from './steps/panel-overview';
 import { isKindStep, makeKindStep } from './steps/kind';
+import { isSourceStep, makeSourceStep } from './steps/source';
 import {
   STEP_DOWNLOAD,
   isDownloadStep,
@@ -68,7 +69,8 @@ const CustomButtons = (props: WizardButtonsProps) => {
 const STEP_TITLE_PANEL_PARENT = 'Create panel';
 
 export function stageFromStepName(name: string): CreatorWizardStage {
-  if (isKindStep(name) || isDetailsStep(name)) return { type: 'card' };
+  if (isSourceStep(name) || isKindStep(name) || isDetailsStep(name))
+    return { type: 'card' };
 
   if (isPanelOverviewStep(name)) return { type: 'panel-overview' };
 
@@ -113,6 +115,7 @@ export function makeSchema(chrome: ChromeAPI, filterData: FilterData): Schema {
     isDynamic: true,
     crossroads: [NAME_KIND, NAME_TASK_TITLES],
     fields: [
+      makeSourceStep(),
       makeKindStep(),
       ...ALL_ITEM_KINDS.map((kind) =>
         makeDetailsStep({

--- a/src/components/creator/schema.tsx
+++ b/src/components/creator/schema.tsx
@@ -91,7 +91,7 @@ export function stageFromStepName(name: string): CreatorWizardStage {
   throw new Error('unable to parse step name: ' + name);
 }
 
-export function makeSchema(chrome: ChromeAPI, filterData: FilterData): Schema {
+export function makeSchema(chrome: ChromeAPI, filterData: FilterData, showGitService = false): Schema {
   const bundles = chrome.getAvailableBundles();
 
   const taskSteps = [];
@@ -115,7 +115,7 @@ export function makeSchema(chrome: ChromeAPI, filterData: FilterData): Schema {
     isDynamic: true,
     crossroads: [NAME_KIND, NAME_TASK_TITLES],
     fields: [
-      makeSourceStep(),
+      ...(showGitService ? [makeSourceStep()] : []),
       makeKindStep(),
       ...ALL_ITEM_KINDS.map((kind) =>
         makeDetailsStep({

--- a/src/components/creator/steps/common.ts
+++ b/src/components/creator/steps/common.ts
@@ -5,6 +5,7 @@ export const REQUIRED = {
 } as const;
 
 export const NAME_KIND = 'kind';
+export const NAME_METADATA_NAME = 'metadata-name';
 export const NAME_TAGS = 'tags';
 export const NAME_TITLE = 'title';
 export const NAME_BUNDLES = 'bundles';

--- a/src/components/creator/steps/kind.tsx
+++ b/src/components/creator/steps/kind.tsx
@@ -3,7 +3,7 @@ import { ALL_ITEM_KINDS, ALL_KIND_ENTRIES } from '../meta';
 import { NAME_KIND, REQUIRED } from './common';
 import { detailsStepName } from './details';
 
-const STEP_KIND = 'step-kind';
+export const STEP_KIND = 'step-kind';
 
 export function isKindStep(name: string): boolean {
   return name === STEP_KIND;

--- a/src/components/creator/steps/source.tsx
+++ b/src/components/creator/steps/source.tsx
@@ -1,0 +1,25 @@
+import { STEP_KIND } from './kind';
+import { REQUIRED } from './common';
+
+export const STEP_SOURCE = 'step-source';
+export const NAME_SOURCE = 'source';
+
+export function isSourceStep(name: string): boolean {
+  return name === STEP_SOURCE;
+}
+
+export function makeSourceStep() {
+  return {
+    name: STEP_SOURCE,
+    title: 'Select source',
+    fields: [
+      {
+        component: 'lr-source-selector',
+        name: NAME_SOURCE,
+        isRequired: true,
+        validate: [REQUIRED],
+      },
+    ],
+    nextStep: STEP_KIND,
+  };
+}

--- a/src/components/creator/useCreatePR.ts
+++ b/src/components/creator/useCreatePR.ts
@@ -1,9 +1,9 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import {
   PRResponse,
   createQuickstartPR,
-  quickstartExists,
+  listRepoQuickstarts,
 } from '../../utils/createQuickstartPR';
 import { CreatorWizardContext } from './context';
 
@@ -14,15 +14,6 @@ export function useCreatePR(quickstartName: string | null) {
   const [prLoading, setPrLoading] = useState(false);
   const [prResult, setPrResult] = useState<PRResponse | null>(null);
   const [prError, setPrError] = useState<string | null>(null);
-  const [isUpdate, setIsUpdate] = useState(false);
-
-  useEffect(() => {
-    if (quickstartName && quickstartName !== 'untitled-quickstart') {
-      quickstartExists(quickstartName).then(setIsUpdate);
-    } else {
-      setIsUpdate(false);
-    }
-  }, [quickstartName]);
 
   const canCreatePR =
     files.length > 0 &&
@@ -36,6 +27,25 @@ export function useCreatePR(quickstartName: string | null) {
     setPrError(null);
     try {
       const timestamp = Date.now();
+      const safeName = quickstartName
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^[-.]+|[-.]+$/g, '');
+      if (!safeName) {
+        setPrError('Quickstart name is not valid for a branch name.');
+        setPrLoading(false);
+        return;
+      }
+
+      let isUpdate = false;
+      try {
+        const repoEntries = await listRepoQuickstarts();
+        isUpdate = repoEntries.some((e) => e.name === quickstartName);
+      } catch {
+        // If repo check fails, default to create
+      }
+
       const prefix = isUpdate ? 'update' : 'create';
       let commitMessage = `feat(quickstarts): ${prefix} ${quickstartName}`;
       const user = await chrome.auth.getUser();
@@ -47,7 +57,7 @@ export function useCreatePR(quickstartName: string | null) {
         commitMessage += `\n\nCo-authored-by: ${name} <${identity.email}>`;
       }
       const result = await createQuickstartPR(files, {
-        branchName: `qs-${prefix}-${quickstartName}-${timestamp}`,
+        branchName: `qs-${prefix}-${safeName}-${timestamp}`,
         commitMessage,
         prTitle: `feat(quickstarts): ${prefix} ${quickstartName}`,
         prBody: `${
@@ -71,7 +81,6 @@ export function useCreatePR(quickstartName: string | null) {
     prLoading,
     prResult,
     prError,
-    isUpdate,
     canCreatePR,
     handleCreatePR,
     setPrResult,

--- a/src/components/creator/useCreatePR.ts
+++ b/src/components/creator/useCreatePR.ts
@@ -1,0 +1,81 @@
+import { useContext, useEffect, useState } from 'react';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import {
+  createQuickstartPR,
+  PRResponse,
+  quickstartExists,
+} from '../../utils/createQuickstartPR';
+import { CreatorWizardContext } from './context';
+
+export function useCreatePR(quickstartName: string | null) {
+  const { files } = useContext(CreatorWizardContext);
+  const chrome = useChrome();
+
+  const [prLoading, setPrLoading] = useState(false);
+  const [prResult, setPrResult] = useState<PRResponse | null>(null);
+  const [prError, setPrError] = useState<string | null>(null);
+  const [isUpdate, setIsUpdate] = useState(false);
+
+  useEffect(() => {
+    if (quickstartName && quickstartName !== 'untitled-quickstart') {
+      quickstartExists(quickstartName).then(setIsUpdate);
+    } else {
+      setIsUpdate(false);
+    }
+  }, [quickstartName]);
+
+  const canCreatePR =
+    files.length > 0 &&
+    !!quickstartName &&
+    quickstartName !== 'untitled-quickstart';
+
+  const handleCreatePR = async () => {
+    if (!quickstartName || prLoading) return;
+    setPrLoading(true);
+    setPrResult(null);
+    setPrError(null);
+    try {
+      const timestamp = Date.now();
+      const prefix = isUpdate ? 'update' : 'create';
+      let commitMessage = `feat(quickstarts): ${prefix} ${quickstartName}`;
+      const user = await chrome.auth.getUser();
+      const identity = user?.identity?.user;
+      if (identity?.email) {
+        const name =
+          [identity.first_name, identity.last_name]
+            .filter(Boolean)
+            .join(' ') || identity.email;
+        commitMessage += `\n\nCo-authored-by: ${name} <${identity.email}>`;
+      }
+      const result = await createQuickstartPR(files, {
+        branchName: `qs-${prefix}-${quickstartName}-${timestamp}`,
+        commitMessage,
+        prTitle: `feat(quickstarts): ${prefix} ${quickstartName}`,
+        prBody: `${
+          isUpdate ? 'Updating' : 'Adding new'
+        } quickstart via the Quickstarts Creator tool.\n\nDirectory: docs/quickstarts/${quickstartName}/`,
+        isUpdate,
+        directoryName: quickstartName,
+        ...(isUpdate
+          ? { existingPath: `docs/quickstarts/${quickstartName}/` }
+          : {}),
+      });
+      setPrResult(result);
+    } catch (err) {
+      setPrError(err instanceof Error ? err.message : 'Failed to create PR');
+    } finally {
+      setPrLoading(false);
+    }
+  };
+
+  return {
+    prLoading,
+    prResult,
+    prError,
+    isUpdate,
+    canCreatePR,
+    handleCreatePR,
+    setPrResult,
+    setPrError,
+  };
+}

--- a/src/components/creator/useCreatePR.ts
+++ b/src/components/creator/useCreatePR.ts
@@ -1,8 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import {
-  createQuickstartPR,
   PRResponse,
+  createQuickstartPR,
   quickstartExists,
 } from '../../utils/createQuickstartPR';
 import { CreatorWizardContext } from './context';
@@ -42,9 +42,8 @@ export function useCreatePR(quickstartName: string | null) {
       const identity = user?.identity?.user;
       if (identity?.email) {
         const name =
-          [identity.first_name, identity.last_name]
-            .filter(Boolean)
-            .join(' ') || identity.email;
+          [identity.first_name, identity.last_name].filter(Boolean).join(' ') ||
+          identity.email;
         commitMessage += `\n\nCo-authored-by: ${name} <${identity.email}>`;
       }
       const result = await createQuickstartPR(files, {

--- a/src/utils/createQuickstartPR.test.ts
+++ b/src/utils/createQuickstartPR.test.ts
@@ -1,17 +1,20 @@
 import axios from 'axios';
 import {
+  PRFile,
+  PRMetadata,
   createQuickstartPR,
   getRepoQuickstartContent,
   listRepoQuickstarts,
-  PRFile,
-  PRMetadata,
 } from './createQuickstartPR';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const MOCK_FILES: PRFile[] = [
-  { name: 'metadata.yaml', content: 'kind: QuickStarts\nmetadata:\n  name: my-qs\n' },
+  {
+    name: 'metadata.yaml',
+    content: 'kind: QuickStarts\nmetadata:\n  name: my-qs\n',
+  },
   { name: 'my-qs.yaml', content: 'spec:\n  displayName: My QS\n' },
 ];
 
@@ -19,7 +22,8 @@ const MOCK_METADATA: PRMetadata = {
   branchName: 'qs-create-my-qs-1234567890',
   commitMessage: 'feat(quickstarts): add my-qs',
   prTitle: 'feat(quickstarts): add my-qs',
-  prBody: 'Adding new quickstart via the Quickstarts Creator tool.\n\nDirectory: docs/quickstarts/my-qs/',
+  prBody:
+    'Adding new quickstart via the Quickstarts Creator tool.\n\nDirectory: docs/quickstarts/my-qs/',
   isUpdate: false,
   directoryName: 'my-qs',
 };
@@ -62,14 +66,20 @@ describe('createQuickstartPR', () => {
   it('propagates network errors', async () => {
     mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
 
-    await expect(createQuickstartPR(MOCK_FILES, MOCK_METADATA)).rejects.toThrow('Network error');
+    await expect(createQuickstartPR(MOCK_FILES, MOCK_METADATA)).rejects.toThrow(
+      'Network error'
+    );
   });
 
   it('propagates 4xx/5xx errors from the API', async () => {
-    const apiError = { response: { status: 502, data: { msg: 'git-service unreachable' } } };
+    const apiError = {
+      response: { status: 502, data: { msg: 'git-service unreachable' } },
+    };
     mockedAxios.post.mockRejectedValueOnce(apiError);
 
-    await expect(createQuickstartPR(MOCK_FILES, MOCK_METADATA)).rejects.toEqual(apiError);
+    await expect(createQuickstartPR(MOCK_FILES, MOCK_METADATA)).rejects.toEqual(
+      apiError
+    );
   });
 
   it('sends isUpdate: false for new quickstarts', async () => {
@@ -83,7 +93,9 @@ describe('createQuickstartPR', () => {
   });
 
   it('forwards existingPath and isUpdate: true for updates (48694 path)', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: { data: { ...MOCK_RESPONSE, status: 'updated' } } });
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { data: { ...MOCK_RESPONSE, status: 'updated' } },
+    });
 
     const updateMetadata: PRMetadata = {
       ...MOCK_METADATA,

--- a/src/utils/createQuickstartPR.test.ts
+++ b/src/utils/createQuickstartPR.test.ts
@@ -1,0 +1,181 @@
+import axios from 'axios';
+import {
+  createQuickstartPR,
+  getRepoQuickstartContent,
+  listRepoQuickstarts,
+  PRFile,
+  PRMetadata,
+} from './createQuickstartPR';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const MOCK_FILES: PRFile[] = [
+  { name: 'metadata.yaml', content: 'kind: QuickStarts\nmetadata:\n  name: my-qs\n' },
+  { name: 'my-qs.yaml', content: 'spec:\n  displayName: My QS\n' },
+];
+
+const MOCK_METADATA: PRMetadata = {
+  branchName: 'qs-create-my-qs-1234567890',
+  commitMessage: 'feat(quickstarts): add my-qs',
+  prTitle: 'feat(quickstarts): add my-qs',
+  prBody: 'Adding new quickstart via the Quickstarts Creator tool.\n\nDirectory: docs/quickstarts/my-qs/',
+  isUpdate: false,
+  directoryName: 'my-qs',
+};
+
+const MOCK_RESPONSE = {
+  prUrl: 'https://github.com/org/repo/pull/42',
+  branchName: 'qs-create-my-qs-1234567890',
+  commitSha: 'abc123def456',
+  status: 'created',
+};
+
+describe('createQuickstartPR', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('POSTs to /api/quickstarts/v1/pull-request with files and metadata', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
+
+    const result = await createQuickstartPR(MOCK_FILES, MOCK_METADATA);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/api/quickstarts/v1/pull-request',
+      { files: MOCK_FILES, metadata: MOCK_METADATA }
+    );
+    expect(result).toEqual(MOCK_RESPONSE);
+  });
+
+  it('returns the PR URL, branchName, commitSha, and status from the response', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
+
+    const result = await createQuickstartPR(MOCK_FILES, MOCK_METADATA);
+
+    expect(result.prUrl).toBe('https://github.com/org/repo/pull/42');
+    expect(result.branchName).toBe('qs-create-my-qs-1234567890');
+    expect(result.commitSha).toBe('abc123def456');
+    expect(result.status).toBe('created');
+  });
+
+  it('propagates network errors', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(createQuickstartPR(MOCK_FILES, MOCK_METADATA)).rejects.toThrow('Network error');
+  });
+
+  it('propagates 4xx/5xx errors from the API', async () => {
+    const apiError = { response: { status: 502, data: { msg: 'git-service unreachable' } } };
+    mockedAxios.post.mockRejectedValueOnce(apiError);
+
+    await expect(createQuickstartPR(MOCK_FILES, MOCK_METADATA)).rejects.toEqual(apiError);
+  });
+
+  it('sends isUpdate: false for new quickstarts', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
+
+    await createQuickstartPR(MOCK_FILES, { ...MOCK_METADATA, isUpdate: false });
+
+    const body = mockedAxios.post.mock.calls[0][1] as { metadata: PRMetadata };
+    expect(body.metadata.isUpdate).toBe(false);
+    expect(body.metadata.existingPath).toBeUndefined();
+  });
+
+  it('forwards existingPath and isUpdate: true for updates (48694 path)', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: { ...MOCK_RESPONSE, status: 'updated' } } });
+
+    const updateMetadata: PRMetadata = {
+      ...MOCK_METADATA,
+      isUpdate: true,
+      existingPath: 'docs/quickstarts/my-qs/',
+    };
+
+    const result = await createQuickstartPR(MOCK_FILES, updateMetadata);
+
+    const body = mockedAxios.post.mock.calls[0][1] as { metadata: PRMetadata };
+    expect(body.metadata.isUpdate).toBe(true);
+    expect(body.metadata.existingPath).toBe('docs/quickstarts/my-qs/');
+    expect(result.status).toBe('updated');
+  });
+});
+
+describe('listRepoQuickstarts', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GETs /api/quickstarts/v1/repo-quickstarts and returns quickstarts array', async () => {
+    const mockQuickstarts = [
+      { name: 'getting-started', displayName: 'Getting Started' },
+      { name: 'cost-management', displayName: 'Cost Management' },
+    ];
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { data: { quickstarts: mockQuickstarts } },
+    });
+
+    const result = await listRepoQuickstarts();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/api/quickstarts/v1/repo-quickstarts'
+    );
+    expect(result).toEqual(mockQuickstarts);
+    expect(result).toHaveLength(2);
+  });
+
+  it('propagates errors', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(listRepoQuickstarts()).rejects.toThrow('Network error');
+  });
+});
+
+describe('getRepoQuickstartContent', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GETs /api/quickstarts/v1/repo-quickstarts/{name} and returns content', async () => {
+    const mockContent = {
+      name: 'getting-started',
+      files: [
+        { name: 'metadata.yaml', content: 'kind: QuickStarts\n' },
+        { name: 'getting-started.yml', content: 'spec:\n  displayName: GS\n' },
+      ],
+    };
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { data: mockContent },
+    });
+
+    const result = await getRepoQuickstartContent('getting-started');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/api/quickstarts/v1/repo-quickstarts/getting-started'
+    );
+    expect(result.name).toBe('getting-started');
+    expect(result.files).toHaveLength(2);
+  });
+
+  it('encodes the quickstart name in the URL', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { data: { name: 'my qs', files: [] } },
+    });
+
+    await getRepoQuickstartContent('my qs');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/api/quickstarts/v1/repo-quickstarts/my%20qs'
+    );
+  });
+
+  it('propagates 404 errors', async () => {
+    const apiError = {
+      response: { status: 404, data: { msg: 'quickstart not found' } },
+    };
+    mockedAxios.get.mockRejectedValueOnce(apiError);
+
+    await expect(getRepoQuickstartContent('nonexistent')).rejects.toEqual(
+      apiError
+    );
+  });
+});

--- a/src/utils/createQuickstartPR.test.ts
+++ b/src/utils/createQuickstartPR.test.ts
@@ -36,20 +36,20 @@ describe('createQuickstartPR', () => {
     jest.clearAllMocks();
   });
 
-  it('POSTs to /api/quickstarts/v1/pull-request with files and metadata', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
+  it('POSTs to /api/v1/submit-pr with files and metadata', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: MOCK_RESPONSE });
 
     const result = await createQuickstartPR(MOCK_FILES, MOCK_METADATA);
 
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      '/api/quickstarts/v1/pull-request',
+      '/api/v1/submit-pr',
       { files: MOCK_FILES, metadata: MOCK_METADATA }
     );
     expect(result).toEqual(MOCK_RESPONSE);
   });
 
   it('returns the PR URL, branchName, commitSha, and status from the response', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
+    mockedAxios.post.mockResolvedValueOnce({ data: MOCK_RESPONSE });
 
     const result = await createQuickstartPR(MOCK_FILES, MOCK_METADATA);
 
@@ -73,7 +73,7 @@ describe('createQuickstartPR', () => {
   });
 
   it('sends isUpdate: false for new quickstarts', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
+    mockedAxios.post.mockResolvedValueOnce({ data: MOCK_RESPONSE });
 
     await createQuickstartPR(MOCK_FILES, { ...MOCK_METADATA, isUpdate: false });
 
@@ -83,7 +83,7 @@ describe('createQuickstartPR', () => {
   });
 
   it('forwards existingPath and isUpdate: true for updates (48694 path)', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: { data: { ...MOCK_RESPONSE, status: 'updated' } } });
+    mockedAxios.post.mockResolvedValueOnce({ data: { ...MOCK_RESPONSE, status: 'updated' } });
 
     const updateMetadata: PRMetadata = {
       ...MOCK_METADATA,
@@ -105,19 +105,19 @@ describe('listRepoQuickstarts', () => {
     jest.clearAllMocks();
   });
 
-  it('GETs /api/quickstarts/v1/repo-quickstarts and returns quickstarts array', async () => {
+  it('GETs /api/v1/list-quickstarts and returns quickstarts array', async () => {
     const mockQuickstarts = [
       { name: 'getting-started', displayName: 'Getting Started' },
       { name: 'cost-management', displayName: 'Cost Management' },
     ];
     mockedAxios.get.mockResolvedValueOnce({
-      data: { data: { quickstarts: mockQuickstarts } },
+      data: { quickstarts: mockQuickstarts },
     });
 
     const result = await listRepoQuickstarts();
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/api/quickstarts/v1/repo-quickstarts'
+      '/api/v1/list-quickstarts'
     );
     expect(result).toEqual(mockQuickstarts);
     expect(result).toHaveLength(2);
@@ -135,7 +135,7 @@ describe('getRepoQuickstartContent', () => {
     jest.clearAllMocks();
   });
 
-  it('GETs /api/quickstarts/v1/repo-quickstarts/{name} and returns content', async () => {
+  it('GETs /api/v1/quickstart-content/{name} and returns content', async () => {
     const mockContent = {
       name: 'getting-started',
       files: [
@@ -144,13 +144,13 @@ describe('getRepoQuickstartContent', () => {
       ],
     };
     mockedAxios.get.mockResolvedValueOnce({
-      data: { data: mockContent },
+      data: mockContent,
     });
 
     const result = await getRepoQuickstartContent('getting-started');
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/api/quickstarts/v1/repo-quickstarts/getting-started'
+      '/api/v1/quickstart-content/getting-started'
     );
     expect(result.name).toBe('getting-started');
     expect(result.files).toHaveLength(2);
@@ -158,13 +158,13 @@ describe('getRepoQuickstartContent', () => {
 
   it('encodes the quickstart name in the URL', async () => {
     mockedAxios.get.mockResolvedValueOnce({
-      data: { data: { name: 'my qs', files: [] } },
+      data: { name: 'my qs', files: [] },
     });
 
     await getRepoQuickstartContent('my qs');
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/api/quickstarts/v1/repo-quickstarts/my%20qs'
+      '/api/v1/quickstart-content/my%20qs'
     );
   });
 

--- a/src/utils/createQuickstartPR.test.ts
+++ b/src/utils/createQuickstartPR.test.ts
@@ -36,20 +36,20 @@ describe('createQuickstartPR', () => {
     jest.clearAllMocks();
   });
 
-  it('POSTs to /api/v1/submit-pr with files and metadata', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: MOCK_RESPONSE });
+  it('POSTs to /api/quickstarts/v1/pull-request with files and metadata', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
 
     const result = await createQuickstartPR(MOCK_FILES, MOCK_METADATA);
 
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      '/api/v1/submit-pr',
+      '/api/quickstarts/v1/pull-request',
       { files: MOCK_FILES, metadata: MOCK_METADATA }
     );
     expect(result).toEqual(MOCK_RESPONSE);
   });
 
   it('returns the PR URL, branchName, commitSha, and status from the response', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: MOCK_RESPONSE });
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
 
     const result = await createQuickstartPR(MOCK_FILES, MOCK_METADATA);
 
@@ -73,7 +73,7 @@ describe('createQuickstartPR', () => {
   });
 
   it('sends isUpdate: false for new quickstarts', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: MOCK_RESPONSE });
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: MOCK_RESPONSE } });
 
     await createQuickstartPR(MOCK_FILES, { ...MOCK_METADATA, isUpdate: false });
 
@@ -83,7 +83,7 @@ describe('createQuickstartPR', () => {
   });
 
   it('forwards existingPath and isUpdate: true for updates (48694 path)', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: { ...MOCK_RESPONSE, status: 'updated' } });
+    mockedAxios.post.mockResolvedValueOnce({ data: { data: { ...MOCK_RESPONSE, status: 'updated' } } });
 
     const updateMetadata: PRMetadata = {
       ...MOCK_METADATA,
@@ -105,19 +105,19 @@ describe('listRepoQuickstarts', () => {
     jest.clearAllMocks();
   });
 
-  it('GETs /api/v1/list-quickstarts and returns quickstarts array', async () => {
+  it('GETs /api/quickstarts/v1/repo-quickstarts and returns quickstarts array', async () => {
     const mockQuickstarts = [
       { name: 'getting-started', displayName: 'Getting Started' },
       { name: 'cost-management', displayName: 'Cost Management' },
     ];
     mockedAxios.get.mockResolvedValueOnce({
-      data: { quickstarts: mockQuickstarts },
+      data: { data: { quickstarts: mockQuickstarts } },
     });
 
     const result = await listRepoQuickstarts();
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/api/v1/list-quickstarts'
+      '/api/quickstarts/v1/repo-quickstarts'
     );
     expect(result).toEqual(mockQuickstarts);
     expect(result).toHaveLength(2);
@@ -135,7 +135,7 @@ describe('getRepoQuickstartContent', () => {
     jest.clearAllMocks();
   });
 
-  it('GETs /api/v1/quickstart-content/{name} and returns content', async () => {
+  it('GETs /api/quickstarts/v1/repo-quickstarts/{name} and returns content', async () => {
     const mockContent = {
       name: 'getting-started',
       files: [
@@ -144,13 +144,13 @@ describe('getRepoQuickstartContent', () => {
       ],
     };
     mockedAxios.get.mockResolvedValueOnce({
-      data: mockContent,
+      data: { data: mockContent },
     });
 
     const result = await getRepoQuickstartContent('getting-started');
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/api/v1/quickstart-content/getting-started'
+      '/api/quickstarts/v1/repo-quickstarts/getting-started'
     );
     expect(result.name).toBe('getting-started');
     expect(result.files).toHaveLength(2);
@@ -158,13 +158,13 @@ describe('getRepoQuickstartContent', () => {
 
   it('encodes the quickstart name in the URL', async () => {
     mockedAxios.get.mockResolvedValueOnce({
-      data: { name: 'my qs', files: [] },
+      data: { data: { name: 'my qs', files: [] } },
     });
 
     await getRepoQuickstartContent('my qs');
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/api/v1/quickstart-content/my%20qs'
+      '/api/quickstarts/v1/repo-quickstarts/my%20qs'
     );
   });
 

--- a/src/utils/createQuickstartPR.ts
+++ b/src/utils/createQuickstartPR.ts
@@ -26,15 +26,11 @@ export interface PRResponse {
 
 export const quickstartExists = async (name: string): Promise<boolean> => {
   if (!name || name === 'untitled-quickstart') return false;
-  try {
-    const { data } = await axios.get<{ data: { content: unknown }[] }>(
-      `${API_BASE}/quickstarts`,
-      { params: { name, limit: 1 } }
-    );
-    return data.data.length > 0;
-  } catch {
-    return false;
-  }
+  const { data } = await axios.get<{ data: { content: unknown }[] }>(
+    `${API_BASE}/quickstarts`,
+    { params: { name, limit: 1 } }
+  );
+  return data.data.length > 0;
 };
 
 export const createQuickstartPR = async (
@@ -62,7 +58,7 @@ export const listRepoQuickstarts = async (): Promise<RepoQuickstartEntry[]> => {
   const { data } = await axios.get<{
     data: { quickstarts: RepoQuickstartEntry[] };
   }>(`${API_BASE}/repo-quickstarts`);
-  return data.data.quickstarts;
+  return data.data?.quickstarts ?? [];
 };
 
 export const getRepoQuickstartContent = async (

--- a/src/utils/createQuickstartPR.ts
+++ b/src/utils/createQuickstartPR.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 export const API_BASE = '/api/quickstarts/v1';
-export const GIT_API_BASE = '/api/v1';
 
 export interface PRFile {
   name: string;
@@ -42,11 +41,11 @@ export const createQuickstartPR = async (
   files: PRFile[],
   metadata: PRMetadata
 ): Promise<PRResponse> => {
-  const { data } = await axios.post<PRResponse>(
-    `${GIT_API_BASE}/submit-pr`,
+  const { data } = await axios.post<{ data: PRResponse }>(
+    `${API_BASE}/pull-request`,
     { files, metadata }
   );
-  return data;
+  return data.data;
 };
 
 export interface RepoQuickstartEntry {
@@ -60,17 +59,17 @@ export interface RepoQuickstartContent {
 }
 
 export const listRepoQuickstarts = async (): Promise<RepoQuickstartEntry[]> => {
-  const { data } = await axios.get<{ quickstarts: RepoQuickstartEntry[] }>(
-    `${GIT_API_BASE}/list-quickstarts`
-  );
-  return data.quickstarts;
+  const { data } = await axios.get<{
+    data: { quickstarts: RepoQuickstartEntry[] };
+  }>(`${API_BASE}/repo-quickstarts`);
+  return data.data.quickstarts;
 };
 
 export const getRepoQuickstartContent = async (
   name: string
 ): Promise<RepoQuickstartContent> => {
-  const { data } = await axios.get<RepoQuickstartContent>(
-    `${GIT_API_BASE}/quickstart-content/${encodeURIComponent(name)}`
+  const { data } = await axios.get<{ data: RepoQuickstartContent }>(
+    `${API_BASE}/repo-quickstarts/${encodeURIComponent(name)}`
   );
-  return data;
+  return data.data;
 };

--- a/src/utils/createQuickstartPR.ts
+++ b/src/utils/createQuickstartPR.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 export const API_BASE = '/api/quickstarts/v1';
+export const GIT_API_BASE = '/api/v1';
 
 export interface PRFile {
   name: string;
@@ -41,11 +42,11 @@ export const createQuickstartPR = async (
   files: PRFile[],
   metadata: PRMetadata
 ): Promise<PRResponse> => {
-  const { data } = await axios.post<{ data: PRResponse }>(
-    `${API_BASE}/pull-request`,
+  const { data } = await axios.post<PRResponse>(
+    `${GIT_API_BASE}/submit-pr`,
     { files, metadata }
   );
-  return data.data;
+  return data;
 };
 
 export interface RepoQuickstartEntry {
@@ -59,17 +60,17 @@ export interface RepoQuickstartContent {
 }
 
 export const listRepoQuickstarts = async (): Promise<RepoQuickstartEntry[]> => {
-  const { data } = await axios.get<{
-    data: { quickstarts: RepoQuickstartEntry[] };
-  }>(`${API_BASE}/repo-quickstarts`);
-  return data.data.quickstarts;
+  const { data } = await axios.get<{ quickstarts: RepoQuickstartEntry[] }>(
+    `${GIT_API_BASE}/list-quickstarts`
+  );
+  return data.quickstarts;
 };
 
 export const getRepoQuickstartContent = async (
   name: string
 ): Promise<RepoQuickstartContent> => {
-  const { data } = await axios.get<{ data: RepoQuickstartContent }>(
-    `${API_BASE}/repo-quickstarts/${encodeURIComponent(name)}`
+  const { data } = await axios.get<RepoQuickstartContent>(
+    `${GIT_API_BASE}/quickstart-content/${encodeURIComponent(name)}`
   );
-  return data.data;
+  return data;
 };

--- a/src/utils/createQuickstartPR.ts
+++ b/src/utils/createQuickstartPR.ts
@@ -1,0 +1,75 @@
+import axios from 'axios';
+
+export const API_BASE = '/api/quickstarts/v1';
+
+export interface PRFile {
+  name: string;
+  content: string;
+}
+
+export interface PRMetadata {
+  branchName: string;
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+  isUpdate: boolean;
+  existingPath?: string;
+  directoryName?: string;
+}
+
+export interface PRResponse {
+  prUrl: string;
+  branchName: string;
+  commitSha: string;
+  status: string;
+}
+
+export const quickstartExists = async (name: string): Promise<boolean> => {
+  if (!name || name === 'untitled-quickstart') return false;
+  try {
+    const { data } = await axios.get<{ data: { content: unknown }[] }>(
+      `${API_BASE}/quickstarts`,
+      { params: { name, limit: 1 } }
+    );
+    return data.data.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+export const createQuickstartPR = async (
+  files: PRFile[],
+  metadata: PRMetadata
+): Promise<PRResponse> => {
+  const { data } = await axios.post<{ data: PRResponse }>(
+    `${API_BASE}/pull-request`,
+    { files, metadata }
+  );
+  return data.data;
+};
+
+export interface RepoQuickstartEntry {
+  name: string;
+  displayName: string;
+}
+
+export interface RepoQuickstartContent {
+  name: string;
+  files: PRFile[];
+}
+
+export const listRepoQuickstarts = async (): Promise<RepoQuickstartEntry[]> => {
+  const { data } = await axios.get<{
+    data: { quickstarts: RepoQuickstartEntry[] };
+  }>(`${API_BASE}/repo-quickstarts`);
+  return data.data.quickstarts;
+};
+
+export const getRepoQuickstartContent = async (
+  name: string
+): Promise<RepoQuickstartContent> => {
+  const { data } = await axios.get<{ data: RepoQuickstartContent }>(
+    `${API_BASE}/repo-quickstarts/${encodeURIComponent(name)}`
+  );
+  return data.data;
+};


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

[RHCLOUD-48689](https://redhat.atlassian.net/browse/RHCLOUD-48689)
[RHCLOUD-48694](https://redhat.atlassian.net/browse/RHCLOUD-48694)

Adds git-service integration to the quickstarts creator, enabling users to submit new quickstarts as pull requests directly from the UI and browse/load existing quickstarts from the GitHub repo. All changes are gated behind the `platform.learning-resources.quickstarts.git-service` Unleash flag.

**Changes:**
- Added "Create PR" button to both the wizard review step and the YAML editor view, powered by a new `useCreatePR` hook
- Added a source selection step to the wizard allowing users to create from scratch or load an existing quickstart from the repo (`SourceSelector.tsx`)
- Added `createQuickstartPR` API utility (`src/utils/createQuickstartPR.ts`) for submitting PRs to the backend git-service
- Restructured the creator tab and wizard step organization
- Added unit tests for `CreatorYAMLView`, `createQuickstartPR`, and updated `CreatorWizard` tests

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:
<img width="1314" height="686" alt="Screenshot 2026-08-07 at 9 12 11 AM" src="https://github.com/user-attachments/assets/4e991172-7e5d-4eb6-9359-6bef2429e915" />

<img width="1460" height="490" alt="Screenshot 2026-08-07 at 9 12 04 AM" src="https://github.com/user-attachments/assets/50cca323-151d-4755-ab3e-3a6e676ca985" />
<img width="874" height="608" alt="Screenshot 2026-08-07 at 9 11 47 AM" src="https://github.com/user-attachments/assets/d3e18a84-5970-4396-906d-c51aaa9314be" />

#### After:
<img width="1170" height="620" alt="Screenshot 2026-08-07 at 8 36 32 AM" src="https://github.com/user-attachments/assets/63d6d003-618c-4995-ae80-ba18b3ca9ac7" />

<img width="832" height="519" alt="image" src="https://github.com/user-attachments/assets/3cb34b58-c0ff-45c2-b6bb-d874e9ef7e77" />

<img width="1184" height="679" alt="Screenshot 2026-08-07 at 3 50 21 PM" src="https://github.com/user-attachments/assets/cf9a6297-828c-4458-b07d-130e9c700337" />

<img width="1236" height="669" alt="Screenshot 2026-08-07 at 3 50 08 PM" src="https://github.com/user-attachments/assets/5a6c94a2-d283-445f-a79b-56e975c4ee06" />


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->
The Unleash flag `platform.learning-resources.quickstarts.git-service` is currently **disabled** in all environments. No user-facing changes until the flag is enabled.

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code

[RHCLOUD-48689]: https://redhat.atlassian.net/browse/RHCLOUD-48689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-48694]: https://redhat.atlassian.net/browse/RHCLOUD-48694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ